### PR TITLE
Add atomic replay migration for RoboSyn action banks

### DIFF
--- a/configs/click_bell/clear/gym_config.json
+++ b/configs/click_bell/clear/gym_config.json
@@ -116,7 +116,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/click_bell",
+                    "save_path": "lerobot_dataset/click_bell",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -310,7 +310,7 @@
     "articulation": [
         {
             "uid": "button",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/button/button.urdf",
+            "fpath": "RoboSynChallenge/assets/button/button.urdf",
             "init_pos": [0.7, 0.3, 0.83],
             "init_rot": [0, 0, 0],
             "attrs": {

--- a/configs/click_bell/gym_config_align_real.json
+++ b/configs/click_bell/gym_config_align_real.json
@@ -108,7 +108,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/Click_Button",
+                    "save_path": "lerobot_dataset/Click_Button",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -307,7 +307,7 @@
     "articulation": [
         {
             "uid": "button",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/button/button.urdf",
+            "fpath": "RoboSynChallenge/assets/button/button.urdf",
             "init_pos": [0.7, 0.3, 0.83],
             "init_rot": [0, 0, 0],
             "attrs": {

--- a/configs/click_bell/gym_config_random_test.json
+++ b/configs/click_bell/gym_config_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "button", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -115,7 +115,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -262,7 +262,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/click_bell",
+                    "save_path": "lerobot_dataset/click_bell",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -456,7 +456,7 @@
     "articulation": [
         {
             "uid": "button",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/button/button.urdf",
+            "fpath": "RoboSynChallenge/assets/button/button.urdf",
             "init_pos": [0.7, 0.3, 0.83],
             "init_rot": [0, 0, 0],
             "attrs": {
@@ -478,7 +478,7 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -497,7 +497,7 @@
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/click_bell/gym_config_table_height.json
+++ b/configs/click_bell/gym_config_table_height.json
@@ -108,7 +108,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/Click_Button",
+                    "save_path": "lerobot_dataset/Click_Button",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -324,7 +324,7 @@
     "articulation": [
         {
             "uid": "button",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/button/button.urdf",
+            "fpath": "RoboSynChallenge/assets/button/button.urdf",
             "init_pos": [0.7, 0.3, 0.83],
             "init_rot": [0, 0, 0],
             "attrs": {

--- a/configs/click_bell/random/gym_config.json
+++ b/configs/click_bell/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "button", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -115,7 +115,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -236,7 +236,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/click_bell",
+                    "save_path": "lerobot_dataset/click_bell",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -430,7 +430,7 @@
     "articulation": [
         {
             "uid": "button",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/button/button.urdf",
+            "fpath": "RoboSynChallenge/assets/button/button.urdf",
             "init_pos": [0.7, 0.3, 0.83],
             "init_rot": [0, 0, 0],
             "attrs": {
@@ -452,7 +452,7 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -471,7 +471,7 @@
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/drawer_open_place/clear/gym_config.json
+++ b/configs/drawer_open_place/clear/gym_config.json
@@ -344,7 +344,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/drawer_open_place",
+                    "save_path": "lerobot_dataset/drawer_open_place",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -569,7 +569,7 @@
             "uid": "duck",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/tomato/tomato_asset_simready/asset_simready.obj"
+                "fpath": "RoboSynChallenge/assets/tomato/tomato_asset_simready/asset_simready.obj"
             },
             "body_scale": [
                 0.8,

--- a/configs/drawer_open_place/gym_config_random_test.json
+++ b/configs/drawer_open_place/gym_config_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "duck"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -105,7 +105,7 @@
                 "params": {
                     "entity_cfg": {"uid": "drawer", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -116,7 +116,7 @@
                 "params": {
                     "entity_cfg": {"uid": "drawer_background", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -152,7 +152,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -500,7 +500,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/drawer_open_place",
+                    "save_path": "lerobot_dataset/drawer_open_place",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -725,7 +725,7 @@
             "uid": "duck",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/tomato/tomato_asset_simready/asset_simready.obj"
+                "fpath": "RoboSynChallenge/assets/tomato/tomato_asset_simready/asset_simready.obj"
             },
             "body_scale": [
                 0.8,
@@ -759,14 +759,14 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ],

--- a/configs/drawer_open_place/random/gym_config.json
+++ b/configs/drawer_open_place/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "duck"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -105,7 +105,7 @@
                 "params": {
                     "entity_cfg": {"uid": "drawer", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -116,7 +116,7 @@
                 "params": {
                     "entity_cfg": {"uid": "drawer_background", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -152,7 +152,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -474,7 +474,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/drawer_open_place",
+                    "save_path": "lerobot_dataset/drawer_open_place",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -699,7 +699,7 @@
             "uid": "duck",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/tomato/tomato_asset_simready/asset_simready.obj"
+                "fpath": "RoboSynChallenge/assets/tomato/tomato_asset_simready/asset_simready.obj"
             },
             "body_scale": [
                 0.8,
@@ -733,14 +733,14 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ],

--- a/configs/handle_basket/action_config.json
+++ b/configs/handle_basket/action_config.json
@@ -1125,6 +1125,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1137,6 +1138,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1149,6 +1151,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1163,6 +1166,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1175,6 +1179,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1187,6 +1192,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/handle_basket/clear/gym_config.json
+++ b/configs/handle_basket/clear/gym_config.json
@@ -240,7 +240,7 @@
         "func": "LeRobotRecorder",
         "mode": "save",
         "params": {
-          "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/handle_basket/",
+          "save_path": "lerobot_dataset/handle_basket/",
           "robot_meta": {
             "robot_type": "CobotMagic",
             "control_freq": 25,
@@ -596,7 +596,7 @@
       "uid": "milk",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/assets/MilkBox/source/Milk_Packaging.glb",
+        "fpath": "RoboSynChallenge/assets/MilkBox/source/Milk_Packaging.glb",
         "compute_uv": true
       },
       "attrs": {
@@ -631,7 +631,7 @@
       "uid": "basket",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/assets/Basket/kago3_deform.obj",
+        "fpath": "RoboSynChallenge/assets/Basket/kago3_deform.obj",
         "compute_uv": true,
         "visual_material": {
           "uid": "basket_mat",

--- a/configs/handle_basket/gym_config_random_test.json
+++ b/configs/handle_basket/gym_config_random_test.json
@@ -180,7 +180,7 @@
             "uid": "table"
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -207,7 +207,7 @@
             ]
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -231,7 +231,7 @@
             "uid": "default_plane"
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -258,7 +258,7 @@
             ]
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -285,7 +285,7 @@
             ]
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -382,7 +382,7 @@
               "uid": "distractor_1"
             }
           ],
-          "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+          "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
           "categories": [
             "PaperCup",
             "fork",
@@ -634,7 +634,7 @@
         "func": "LeRobotRecorder",
         "mode": "save",
         "params": {
-          "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/handle_basket/",
+          "save_path": "lerobot_dataset/handle_basket/",
           "robot_meta": {
             "robot_type": "CobotMagic",
             "control_freq": 25,
@@ -990,7 +990,7 @@
       "uid": "milk",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/assets/MilkBox/source/Milk_Packaging.glb",
+        "fpath": "RoboSynChallenge/assets/MilkBox/source/Milk_Packaging.glb",
         "compute_uv": true
       },
       "attrs": {
@@ -1025,7 +1025,7 @@
       "uid": "basket",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/assets/Basket/kago3_deform.obj",
+        "fpath": "RoboSynChallenge/assets/Basket/kago3_deform.obj",
         "compute_uv": true,
         "visual_material": {
           "uid": "basket_mat",
@@ -1071,14 +1071,14 @@
       "uid": "distractor_0",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+        "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
       }
     },
     {
       "uid": "distractor_1",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+        "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
       }
     }
   ]

--- a/configs/handle_basket/random/gym_config.json
+++ b/configs/handle_basket/random/gym_config.json
@@ -180,7 +180,7 @@
             "uid": "table"
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -207,7 +207,7 @@
             ]
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -231,7 +231,7 @@
             "uid": "default_plane"
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -258,7 +258,7 @@
             ]
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -285,7 +285,7 @@
             ]
           },
           "random_texture_prob": 0.5,
-          "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+          "texture_path": "RoboSynChallenge/assets/background_texture/100",
           "base_color_range": [
             [
               0.2,
@@ -382,7 +382,7 @@
               "uid": "distractor_1"
             }
           ],
-          "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+          "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
           "categories": [
             "PaperCup",
             "fork",
@@ -608,7 +608,7 @@
         "func": "LeRobotRecorder",
         "mode": "save",
         "params": {
-          "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/handle_basket/",
+          "save_path": "lerobot_dataset/handle_basket/",
           "robot_meta": {
             "robot_type": "CobotMagic",
             "control_freq": 25,
@@ -964,7 +964,7 @@
       "uid": "milk",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/assets/MilkBox/source/Milk_Packaging.glb",
+        "fpath": "RoboSynChallenge/assets/MilkBox/source/Milk_Packaging.glb",
         "compute_uv": true
       },
       "attrs": {
@@ -999,7 +999,7 @@
       "uid": "basket",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/assets/Basket/kago3_deform.obj",
+        "fpath": "RoboSynChallenge/assets/Basket/kago3_deform.obj",
         "compute_uv": true,
         "visual_material": {
           "uid": "basket_mat",
@@ -1045,14 +1045,14 @@
       "uid": "distractor_0",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+        "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
       }
     },
     {
       "uid": "distractor_1",
       "shape": {
         "shape_type": "Mesh",
-        "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+        "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
       }
     }
   ]

--- a/configs/item_assembly/action_config.json
+++ b/configs/item_assembly/action_config.json
@@ -1524,6 +1524,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1536,6 +1537,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1551,6 +1553,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1563,6 +1566,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/item_assembly/clear/gym_config.json
+++ b/configs/item_assembly/clear/gym_config.json
@@ -177,7 +177,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/item_assembly",
+                    "save_path": "lerobot_dataset/item_assembly",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -384,7 +384,7 @@
             "uid":"guijiao2",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/guijiao_standard/1guijiao_standard.ply",
+                "fpath": "RoboSynChallenge/assets/guijiao_standard/1guijiao_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -406,7 +406,7 @@
             "uid":"guijiao1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/guijiao_standard/2guijiao_standard.ply",
+                "fpath": "RoboSynChallenge/assets/guijiao_standard/2guijiao_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/item_assembly/random/gym_config.json
+++ b/configs/item_assembly/random/gym_config.json
@@ -70,7 +70,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -81,7 +81,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -92,7 +92,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -103,7 +103,7 @@
                 "params": {
                     "entity_cfg": {"uid": "guijiao1"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -114,7 +114,7 @@
                 "params": {
                     "entity_cfg": {"uid": "guijiao2"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -144,7 +144,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -317,7 +317,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/item_assembly",
+                    "save_path": "lerobot_dataset/item_assembly",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -524,7 +524,7 @@
             "uid":"guijiao2",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/guijiao_standard/1guijiao_standard.ply",
+                "fpath": "RoboSynChallenge/assets/guijiao_standard/1guijiao_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -546,7 +546,7 @@
             "uid":"guijiao1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/guijiao_standard/2guijiao_standard.ply",
+                "fpath": "RoboSynChallenge/assets/guijiao_standard/2guijiao_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -568,7 +568,7 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         },
@@ -576,7 +576,7 @@
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         }

--- a/configs/items_handover/action_config.json
+++ b/configs/items_handover/action_config.json
@@ -1095,6 +1095,7 @@
                     "duration": 15,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1107,6 +1108,7 @@
                     "duration": 15,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1119,6 +1121,7 @@
                     "duration": 10,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1133,6 +1136,7 @@
                     "duration": 15,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1145,6 +1149,7 @@
                     "duration": 15,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1157,6 +1162,7 @@
                     "duration": 10,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/items_handover/clear/gym_config.json
+++ b/configs/items_handover/clear/gym_config.json
@@ -169,7 +169,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/items_handover/",
+                    "save_path": "lerobot_dataset/items_handover/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -376,7 +376,7 @@
             "uid":"holder",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/PenHolder/pen_holder.obj",
+                "fpath": "RoboSynChallenge/assets/PenHolder/pen_holder.obj",
                 "compute_uv": true
             },
             "attrs" : {
@@ -397,7 +397,7 @@
             "uid":"pen",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pen/the_pen.obj",
+                "fpath": "RoboSynChallenge/assets/Pen/the_pen.obj",
                 "compute_uv": true,
                 "visual_material": {
                     "uid": "black_pen_mat",

--- a/configs/items_handover/gym_config_random_test.json
+++ b/configs/items_handover/gym_config_random_test.json
@@ -70,7 +70,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -81,7 +81,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -92,7 +92,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -103,7 +103,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pen"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -114,7 +114,7 @@
                 "params": {
                     "entity_cfg": {"uid": "holder"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -146,7 +146,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -342,7 +342,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/items_handover/",
+                    "save_path": "lerobot_dataset/items_handover/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -549,7 +549,7 @@
             "uid":"holder",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/PenHolder/pen_holder.obj",
+                "fpath": "RoboSynChallenge/assets/PenHolder/pen_holder.obj",
                 "compute_uv": true
             },
             "attrs" : {
@@ -570,7 +570,7 @@
             "uid":"pen",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pen/the_pen.obj",
+                "fpath": "RoboSynChallenge/assets/Pen/the_pen.obj",
                 "compute_uv": true,
                 "visual_material": {
                     "uid": "black_pen_mat",
@@ -597,7 +597,7 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         },
@@ -605,7 +605,7 @@
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         }

--- a/configs/items_handover/random/gym_config.json
+++ b/configs/items_handover/random/gym_config.json
@@ -70,7 +70,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -81,7 +81,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -92,7 +92,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -103,7 +103,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pen"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -114,7 +114,7 @@
                 "params": {
                     "entity_cfg": {"uid": "holder"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -146,7 +146,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -316,7 +316,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/items_handover/",
+                    "save_path": "lerobot_dataset/items_handover/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -523,7 +523,7 @@
             "uid":"holder",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/PenHolder/pen_holder.obj",
+                "fpath": "RoboSynChallenge/assets/PenHolder/pen_holder.obj",
                 "compute_uv": true
             },
             "attrs" : {
@@ -544,7 +544,7 @@
             "uid":"pen",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pen/the_pen.obj",
+                "fpath": "RoboSynChallenge/assets/Pen/the_pen.obj",
                 "compute_uv": true,
                 "visual_material": {
                     "uid": "black_pen_mat",
@@ -571,7 +571,7 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         },
@@ -579,7 +579,7 @@
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         }

--- a/configs/manipulate_pipette/action_config.json
+++ b/configs/manipulate_pipette/action_config.json
@@ -1095,6 +1095,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1109,6 +1110,7 @@
                     "duration": 10,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1121,6 +1123,7 @@
                     "duration": 30,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/manipulate_pipette/clear/gym_config.json
+++ b/configs/manipulate_pipette/clear/gym_config.json
@@ -207,7 +207,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/manipulate_pipette/",
+                    "save_path": "lerobot_dataset/manipulate_pipette/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -417,7 +417,7 @@
             "uid":"beaker1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -440,7 +440,7 @@
     "articulation": [
         {
             "uid": "pipette",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
+            "fpath": "RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
             "build_pk_chain": false,
             "init_pos": [0.6, -0.25, 0.86],
             "init_rot": [0, -7, 0],

--- a/configs/manipulate_pipette/gym_config_random_test.json
+++ b/configs/manipulate_pipette/gym_config_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pipette", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -143,7 +143,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -353,7 +353,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/manipulate_pipette/",
+                    "save_path": "lerobot_dataset/manipulate_pipette/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -563,7 +563,7 @@
             "uid":"beaker1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -586,21 +586,21 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ],
     "articulation": [
         {
             "uid": "pipette",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
+            "fpath": "RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
             "build_pk_chain": false,
             "init_pos": [0.6, -0.25, 0.86],
             "init_rot": [0, -7, 0],

--- a/configs/manipulate_pipette/random/gym_config.json
+++ b/configs/manipulate_pipette/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pipette", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -143,7 +143,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -327,7 +327,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/manipulate_pipette/",
+                    "save_path": "lerobot_dataset/manipulate_pipette/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -537,7 +537,7 @@
             "uid":"beaker1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -560,21 +560,21 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ],
     "articulation": [
         {
             "uid": "pipette",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
+            "fpath": "RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
             "build_pk_chain": false,
             "init_pos": [0.6, -0.25, 0.86],
             "init_rot": [0, -7, 0],

--- a/configs/mixer_operating/action_config.json
+++ b/configs/mixer_operating/action_config.json
@@ -1090,6 +1090,7 @@
                     "duration": 12,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1102,6 +1103,7 @@
                     "duration": 20,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1114,6 +1116,7 @@
                     "duration": 12,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1128,6 +1131,7 @@
                     "duration": 12,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/mixer_operating/clear/gym_config.json
+++ b/configs/mixer_operating/clear/gym_config.json
@@ -204,7 +204,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/mixer_operating",
+                    "save_path": "lerobot_dataset/mixer_operating",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -417,7 +417,7 @@
             "uid": "beaker",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -441,7 +441,7 @@
             "uid": "beaker_mixer",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
+                "fpath": "RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
                 "compute_uv": false
             },
             "attrs": {

--- a/configs/mixer_operating/gym_config_before.json
+++ b/configs/mixer_operating/gym_config_before.json
@@ -189,7 +189,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/assets/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "plastic_bin", "bottles", "fork", "mouse_pad", "plate", "spoon"],
                     "position_ranges": [
                         [[0.62, -0.20, 0.89], [0.86, -0.03, 0.92]],
@@ -380,7 +380,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/",
+                    "save_path": "lerobot_dataset/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25
@@ -483,7 +483,7 @@
             "uid": "beaker_mixer",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
+                "fpath": "RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
                 "compute_uv": false
             },
             "attrs": {
@@ -510,7 +510,7 @@
             "uid": "beaker",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -534,7 +534,7 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         },
@@ -542,7 +542,7 @@
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             }
         }

--- a/configs/mixer_operating/gym_config_dual_random_test.json
+++ b/configs/mixer_operating/gym_config_dual_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -109,7 +109,7 @@
                 "params": {
                     "entity_cfg": {"uid": "beaker_mixer"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -143,7 +143,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -366,7 +366,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/mixer_operating",
+                    "save_path": "lerobot_dataset/mixer_operating",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -579,7 +579,7 @@
             "uid": "beaker",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -603,7 +603,7 @@
             "uid": "beaker_mixer",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
+                "fpath": "RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
                 "compute_uv": false
             },
             "attrs": {
@@ -627,14 +627,14 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ]

--- a/configs/mixer_operating/random/gym_config.json
+++ b/configs/mixer_operating/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -109,7 +109,7 @@
                 "params": {
                     "entity_cfg": {"uid": "beaker_mixer"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -143,7 +143,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -340,7 +340,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/mixer_operating",
+                    "save_path": "lerobot_dataset/mixer_operating",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -553,7 +553,7 @@
             "uid": "beaker",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply",
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -577,7 +577,7 @@
             "uid": "beaker_mixer",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
+                "fpath": "RoboSynChallenge/assets/beaker_mixer/beaker_mixer.obj",
                 "compute_uv": false
             },
             "attrs": {
@@ -601,14 +601,14 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ]

--- a/configs/other_tasks/manipulate_pipette_two_beaker/action_config.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/action_config.json
@@ -1813,6 +1813,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1827,6 +1828,7 @@
                     "duration": 10,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1839,6 +1841,7 @@
                     "duration": 30,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1851,6 +1854,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/other_tasks/manipulate_pipette_two_beaker/clear/gym_config.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/clear/gym_config.json
@@ -251,7 +251,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/manipulate_pipette/",
+                    "save_path": "lerobot_dataset/manipulate_pipette/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -461,7 +461,7 @@
             "uid":"beaker1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -484,7 +484,7 @@
             "uid":"beaker2",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -507,7 +507,7 @@
     "articulation": [
         {
             "uid": "pipette",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
+            "fpath": "RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
             "build_pk_chain": false,
             "init_pos": [0.6, -0.25, 0.86],
             "init_rot": [0, -7, 0],

--- a/configs/other_tasks/manipulate_pipette_two_beaker/gym_config_two_beaker_random_test.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/gym_config_two_beaker_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pipette", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -169,7 +169,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -371,7 +371,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/manipulate_pipette/",
+                    "save_path": "lerobot_dataset/manipulate_pipette/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -581,7 +581,7 @@
             "uid":"beaker1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -604,7 +604,7 @@
             "uid":"beaker2",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -627,21 +627,21 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ],
     "articulation": [
         {
             "uid": "pipette",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
+            "fpath": "RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
             "build_pk_chain": false,
             "init_pos": [0.6, -0.25, 0.86],
             "init_rot": [0, -7, 0],

--- a/configs/other_tasks/manipulate_pipette_two_beaker/random/gym_config.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pipette", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -169,7 +169,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -371,7 +371,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/manipulate_pipette/",
+                    "save_path": "lerobot_dataset/manipulate_pipette/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -581,7 +581,7 @@
             "uid":"beaker1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -604,7 +604,7 @@
             "uid":"beaker2",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             },
             "attrs" : {
                 "mass": 0.05,
@@ -627,21 +627,21 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ],
     "articulation": [
         {
             "uid": "pipette",
-            "fpath": "/root/workspace/RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
+            "fpath": "RoboSynChallenge/assets/pipette_good/pipette_good.urdf",
             "build_pk_chain": false,
             "init_pos": [0.6, -0.25, 0.86],
             "init_rot": [0, -7, 0],

--- a/configs/other_tasks/open_pan/action_config.json
+++ b/configs/other_tasks/open_pan/action_config.json
@@ -1137,6 +1137,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true
                     }
                 }
@@ -1148,6 +1149,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true
                     }
                 }
@@ -1159,6 +1161,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true
                     }
                 }
@@ -1172,6 +1175,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true
                     }
                 }
@@ -1183,6 +1187,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true
                     }
                 }
@@ -1194,6 +1199,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true
                     }
                 }

--- a/configs/other_tasks/open_pan/clear/gym_config.json
+++ b/configs/other_tasks/open_pan/clear/gym_config.json
@@ -215,7 +215,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/open_pan",
+                    "save_path": "lerobot_dataset/open_pan",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -412,7 +412,7 @@
             "uid": "pan",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pan/pot.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/pot.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -433,7 +433,7 @@
             "uid": "lid",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pan/lid_remeshed.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/lid_remeshed.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -454,7 +454,7 @@
             "uid": "carrot",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Carrot/carrot_centered.obj",
+                "fpath": "RoboSynChallenge/assets/Carrot/carrot_centered.obj",
                 "compute_uv": false
             },
             "attrs": {

--- a/configs/other_tasks/open_pan/gym_config.json
+++ b/configs/other_tasks/open_pan/gym_config.json
@@ -277,7 +277,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/outputs_pan/lerobot/open_pan",
+                    "save_path": "lerobot_dataset/open_pan",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -397,7 +397,7 @@
             "uid": "pan",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/embodichain/lab/gym/envs/tasks/tableware/open_pan/object/pot.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/pot.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -418,7 +418,7 @@
             "uid": "lid",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/embodichain/lab/gym/envs/tasks/tableware/open_pan/object/lid_remeshed.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/lid_remeshed.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -439,7 +439,7 @@
             "uid": "carrot",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/embodichain/lab/gym/envs/tasks/tableware/open_pan/object/carrot_centered.obj",
+                "fpath": "RoboSynChallenge/assets/Carrot/carrot_centered.obj",
                 "compute_uv": true
             },
             "attrs": {

--- a/configs/other_tasks/open_pan/gym_config_random_test.json
+++ b/configs/other_tasks/open_pan/gym_config_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -121,7 +121,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pan"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -132,7 +132,7 @@
                 "params": {
                     "entity_cfg": {"uid": "lid"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -143,7 +143,7 @@
                 "params": {
                     "entity_cfg": {"uid": "carrot"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -155,7 +155,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -383,7 +383,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/open_pan",
+                    "save_path": "lerobot_dataset/open_pan",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -580,7 +580,7 @@
             "uid": "pan",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pan/pot.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/pot.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -601,7 +601,7 @@
             "uid": "lid",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pan/lid_remeshed.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/lid_remeshed.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -622,7 +622,7 @@
             "uid": "carrot",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Carrot/carrot_centered.obj",
+                "fpath": "RoboSynChallenge/assets/Carrot/carrot_centered.obj",
                 "compute_uv": false
             },
             "attrs": {
@@ -643,7 +643,7 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -662,7 +662,7 @@
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/other_tasks/open_pan/random/gym_config.json
+++ b/configs/other_tasks/open_pan/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -121,7 +121,7 @@
                 "params": {
                     "entity_cfg": {"uid": "pan"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -132,7 +132,7 @@
                 "params": {
                     "entity_cfg": {"uid": "lid"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -143,7 +143,7 @@
                 "params": {
                     "entity_cfg": {"uid": "carrot"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -155,7 +155,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -357,7 +357,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/open_pan",
+                    "save_path": "lerobot_dataset/open_pan",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -554,7 +554,7 @@
             "uid": "pan",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pan/pot.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/pot.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -575,7 +575,7 @@
             "uid": "lid",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Pan/lid_remeshed.ply",
+                "fpath": "RoboSynChallenge/assets/Pan/lid_remeshed.ply",
                 "compute_uv": true
             },
             "attrs": {
@@ -596,7 +596,7 @@
             "uid": "carrot",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Carrot/carrot_centered.obj",
+                "fpath": "RoboSynChallenge/assets/Carrot/carrot_centered.obj",
                 "compute_uv": false
             },
             "attrs": {
@@ -617,7 +617,7 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -636,7 +636,7 @@
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/other_tasks/pour_water/action_config.json
+++ b/configs/other_tasks/pour_water/action_config.json
@@ -883,6 +883,7 @@
                     "duration": 10,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -895,6 +896,7 @@
                     "duration": 10,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/other_tasks/sample_loading/action_config.json
+++ b/configs/other_tasks/sample_loading/action_config.json
@@ -1053,6 +1053,7 @@
                     "duration": 35,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1065,6 +1066,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/other_tasks/sample_loading/gym_config.json
+++ b/configs/other_tasks/sample_loading/gym_config.json
@@ -385,7 +385,7 @@
             "uid":"cube",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -409,7 +409,7 @@
             "uid":"rack",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_rack_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_rack_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/sample_loading/action_config.json
+++ b/configs/sample_loading/action_config.json
@@ -1327,6 +1327,7 @@
                     "duration": 20,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1339,6 +1340,7 @@
                     "duration": 20,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1351,6 +1353,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1365,6 +1368,7 @@
                     "duration": 10,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1377,6 +1381,7 @@
                     "duration": 20,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1389,6 +1394,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/sample_loading/clear/gym_config.json
+++ b/configs/sample_loading/clear/gym_config.json
@@ -169,7 +169,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/sample_loading/",
+                    "save_path": "lerobot_dataset/sample_loading/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -365,7 +365,7 @@
             "uid":"cube",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -389,7 +389,7 @@
             "uid":"rack",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_rack_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_rack_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/sample_loading/gym_config_random_test.json
+++ b/configs/sample_loading/gym_config_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "rack"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -144,7 +144,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -331,7 +331,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/sample_loading/",
+                    "save_path": "lerobot_dataset/sample_loading/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -527,7 +527,7 @@
             "uid":"cube",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -551,7 +551,7 @@
             "uid":"rack",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_rack_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_rack_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -574,14 +574,14 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ]

--- a/configs/sample_loading/random/gym_config.json
+++ b/configs/sample_loading/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "rack"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -144,7 +144,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -305,7 +305,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/sample_loading/",
+                    "save_path": "lerobot_dataset/sample_loading/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -501,7 +501,7 @@
             "uid":"cube",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -525,7 +525,7 @@
             "uid":"rack",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/test_tube_rack_standard.ply",
+                "fpath": "RoboSynChallenge/assets/test_tube_rack_standard.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -548,14 +548,14 @@
             "uid": "distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         },
         {
             "uid": "distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/Beaker/beaker.ply"
+                "fpath": "RoboSynChallenge/assets/Beaker/beaker.ply"
             }
         }
     ]

--- a/configs/table_rearrangement/action_config.json
+++ b/configs/table_rearrangement/action_config.json
@@ -1285,6 +1285,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1297,6 +1298,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1309,6 +1311,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1323,6 +1326,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1335,6 +1339,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1347,6 +1352,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/table_rearrangement/clear/gym_config.json
+++ b/configs/table_rearrangement/clear/gym_config.json
@@ -137,7 +137,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/table_rearrangement",
+                    "save_path": "lerobot_dataset/table_rearrangement",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,

--- a/configs/table_rearrangement/gym_config_random_test.json
+++ b/configs/table_rearrangement/gym_config_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "fork", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "spoon", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "plate", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -105,7 +105,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -116,7 +116,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -128,7 +128,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.55, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -305,7 +305,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/table_rearrangement",
+                    "save_path": "lerobot_dataset/table_rearrangement",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -552,7 +552,7 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -571,7 +571,7 @@
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/table_rearrangement/random/gym_config.json
+++ b/configs/table_rearrangement/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "fork", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "spoon", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "plate", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -105,7 +105,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -116,7 +116,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -128,7 +128,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.55, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -279,7 +279,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/table_rearrangement",
+                    "save_path": "lerobot_dataset/table_rearrangement",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -526,7 +526,7 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {
@@ -545,7 +545,7 @@
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply",
                 "compute_uv": true
             },
             "attrs" : {

--- a/configs/water_pouring/action_config.json
+++ b/configs/water_pouring/action_config.json
@@ -1405,6 +1405,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1417,6 +1418,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "left_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1431,6 +1433,7 @@
                     "duration": 11,
                     "name": "execute_open",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }
@@ -1443,6 +1446,7 @@
                     "duration": 11,
                     "name": "execute_close",
                     "kwargs": {
+                        "control_part": "right_eef",
                         "return_action": true,
                         "expand": true
                     }

--- a/configs/water_pouring/clear/gym_config.json
+++ b/configs/water_pouring/clear/gym_config.json
@@ -166,7 +166,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/water_pouring/",
+                    "save_path": "lerobot_dataset/water_pouring/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -388,7 +388,7 @@
             "uid":"bottle",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/bottle/bottle.obj",
+                "fpath": "RoboSynChallenge/assets/bottle/bottle.obj",
                 "compute_uv": false
             },
             "attrs" : {

--- a/configs/water_pouring/gym_config_dual_green_clear.json
+++ b/configs/water_pouring/gym_config_dual_green_clear.json
@@ -166,7 +166,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/pour_water_dual/",
+                    "save_path": "lerobot_dataset/pour_water_dual/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -363,7 +363,7 @@
             "uid":"cup",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/PaperCup/green_cup.ply",
+                "fpath": "RoboSynChallenge/assets/PaperCup/green_cup.ply",
                 "compute_uv": true,
                 "visual_material": {
                     "uid": "cup_mat",
@@ -388,7 +388,7 @@
             "uid":"bottle",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/bottle/bottle.obj",
+                "fpath": "RoboSynChallenge/assets/bottle/bottle.obj",
                 "compute_uv": false
             },
             "attrs" : {

--- a/configs/water_pouring/gym_config_dual_random_test.json
+++ b/configs/water_pouring/gym_config_dual_random_test.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "cup", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -105,7 +105,7 @@
                 "params": {
                     "entity_cfg": {"uid": "bottle", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -139,7 +139,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -339,7 +339,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/water_pouring/",
+                    "save_path": "lerobot_dataset/water_pouring/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -561,7 +561,7 @@
             "uid":"bottle",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/bottle/bottle.obj",
+                "fpath": "RoboSynChallenge/assets/bottle/bottle.obj",
                 "compute_uv": false
             },
             "attrs" : {
@@ -582,14 +582,14 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
             }
         },
         {
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
             }
         }
     ]

--- a/configs/water_pouring/random/gym_config.json
+++ b/configs/water_pouring/random/gym_config.json
@@ -61,7 +61,7 @@
                 "params": {
                     "entity_cfg": {"uid": "table"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -72,7 +72,7 @@
                 "params": {
                     "entity_cfg": {"uid": "CobotMagic", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -83,7 +83,7 @@
                 "params": {
                     "entity_cfg": {"uid": "default_plane"},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -94,7 +94,7 @@
                 "params": {
                     "entity_cfg": {"uid": "cup", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -105,7 +105,7 @@
                 "params": {
                     "entity_cfg": {"uid": "bottle", "link_names": [".*"]},
                     "random_texture_prob": 0.5,
-                    "texture_path": "/root/workspace/RoboSynChallenge/assets/background_texture/100",
+                    "texture_path": "RoboSynChallenge/assets/background_texture/100",
                     "base_color_range": [[0.2, 0.2, 0.2], [1.0, 1.0, 1.0]]
                 }
             },
@@ -139,7 +139,7 @@
                         {"uid": "distractor_0"},
                         {"uid": "distractor_1"}
                     ],
-                    "library_index_path": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
+                    "library_index_path": "RoboSynChallenge/robosynchallenge/Distractor/ASSET_INDEX.json",
                     "categories": ["PaperCup", "fork", "spoon"],
                     "position_ranges": [
                         [[0.4, -0.35, 0.89], [1.0, 0.35, 0.92]],
@@ -313,7 +313,7 @@
                 "func": "LeRobotRecorder",
                 "mode": "save",
                 "params": {
-                    "save_path": "/root/workspace/RoboSynChallenge/lerobot_dataset/water_pouring/",
+                    "save_path": "lerobot_dataset/water_pouring/",
                     "robot_meta": {
                         "robot_type": "CobotMagic",
                         "control_freq": 25,
@@ -535,7 +535,7 @@
             "uid":"bottle",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/assets/bottle/bottle.obj",
+                "fpath": "RoboSynChallenge/assets/bottle/bottle.obj",
                 "compute_uv": false
             },
             "attrs" : {
@@ -556,14 +556,14 @@
             "uid":"distractor_0",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
             }
         },
         {
             "uid":"distractor_1",
             "shape": {
                 "shape_type": "Mesh",
-                "fpath": "/root/workspace/RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
+                "fpath": "RoboSynChallenge/robosynchallenge/Distractor/PaperCup/paper_cup.ply"
             }
         }
     ]

--- a/robosynchallenge/__init__.py
+++ b/robosynchallenge/__init__.py
@@ -32,6 +32,17 @@ def _get_version():
 
 __version__ = _get_version()
 
+
+def _patch_embodichain_runtime_imports():
+    from embodichain.lab.sim.material import VisualMaterialCfg
+    import embodichain.lab.sim.shapes as shapes
+
+    if not hasattr(shapes, "VisualMaterialCfg"):
+        shapes.VisualMaterialCfg = VisualMaterialCfg
+
+
+_patch_embodichain_runtime_imports()
+
 from . import data as data
 from . import managers as managers
 from . import tasks as tasks

--- a/robosynchallenge/data/constants.py
+++ b/robosynchallenge/data/constants.py
@@ -16,4 +16,11 @@
 
 from pathlib import Path
 
-# Add your constants here. eg, the data download prefix.
+ROBOSYNCHALLENGE_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+class RoboSynChallenge:
+    """Local data namespace for RoboSynChallenge config asset paths."""
+
+    def __init__(self):
+        self.extract_dir = str(ROBOSYNCHALLENGE_PROJECT_ROOT)

--- a/robosynchallenge/tasks/__init__.py
+++ b/robosynchallenge/tasks/__init__.py
@@ -68,21 +68,12 @@ from .sample_loading.sample_loading import (
 
 
 # Competition-irrelevant tasks
-# from ._other_tasks.open_pan.open_pan import (
-#     OpenPanPickAndPlaceEnv,
-#     OpenPanPickAndPlaceTestEnv,
-#     OpenPanPickAndPlaceAgentEnv,
-# )
-# from ._other_tasks.sample_loading.sample_loading import (
-#     SampleLoadingEnv,
-#     SampleLoadingAgentEnv,
-# )
-# from ._other_tasks.manipulate_pipette_two_beaker.manipulate_pipette_two_beaker import (
-#     ManipulatePipetteTwoBeakerEnv,
-#     ManipulatePipetteTwoBeakerTestEnv,
-#     ManipulatePipetteTwoBeakerAgentEnv,
-# )
-# from ._other_tasks.pour_water.pour_water import (
-#     PourWaterEnv,
-#     PourWaterAgentEnv,
-# )
+from ._other_tasks.open_pan import open_pan as _open_pan
+from ._other_tasks.manipulate_pipette_two_beaker import (
+    manipulate_pipette_two_beaker as _manipulate_pipette_two_beaker,
+)
+
+# Do not import _other_tasks.sample_loading here. Gymnasium disallows registering
+# SampleLoading-v1 while the official unversioned SampleLoading env is registered.
+# Do not import _other_tasks.pour_water here. Gymnasium disallows registering
+# unversioned PourWater while EmbodiChain's PourWater-v3 env is registered.

--- a/robosynchallenge/tasks/_other_tasks/manipulate_pipette_two_beaker/action_bank.py
+++ b/robosynchallenge/tasks/_other_tasks/manipulate_pipette_two_beaker/action_bank.py
@@ -21,7 +21,6 @@ from typing import Dict, List
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
     tag_node,
-    tag_edge,
 )
 
 from embodichain.lab.gym.utils.misc import (
@@ -41,12 +40,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ...atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["ManipulatePipetteTwoBeakerActionBank"]
 
 
-class ManipulatePipetteTwoBeakerActionBank(ActionBank):
+class ManipulatePipetteTwoBeakerActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
 
     @staticmethod
     @tag_node
@@ -192,8 +192,6 @@ class ManipulatePipetteTwoBeakerActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -231,8 +229,6 @@ class ManipulatePipetteTwoBeakerActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -270,7 +266,6 @@ class ManipulatePipetteTwoBeakerActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -327,7 +322,6 @@ class ManipulatePipetteTwoBeakerActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/_other_tasks/open_pan/action_bank.py
+++ b/robosynchallenge/tasks/_other_tasks/open_pan/action_bank.py
@@ -24,7 +24,6 @@ import torch
 
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
-    tag_edge,
     tag_node,
 )
 from embodichain.lab.gym.utils.misc import (
@@ -43,11 +42,12 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ...atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 __all__ = ["OpenPanPickandPlaceActionBank", "OpenPanActionBank"]
 
 
-class OpenPanPickandPlaceActionBank(ActionBank):
+class OpenPanPickandPlaceActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -519,8 +519,6 @@ class OpenPanPickandPlaceActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
             duration = kwargs.get("duration", 1)
@@ -534,8 +532,6 @@ class OpenPanPickandPlaceActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
         if return_action:
             duration = kwargs.get("duration", 1)
@@ -549,7 +545,6 @@ class OpenPanPickandPlaceActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
     def stand_still(env, agent_uid: str, keypose_names: List[str], duration: int):
         keyposes = [env.affordance_datas[keypose_name] for keypose_name in keypose_names]
         stand_still_qpos = keyposes[0]
@@ -571,7 +566,6 @@ class OpenPanPickandPlaceActionBank(ActionBank):
         return ret.T
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/_other_tasks/pour_water/action_bank.py
+++ b/robosynchallenge/tasks/_other_tasks/pour_water/action_bank.py
@@ -41,12 +41,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ...atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["PourWaterActionBank"]
 
 
-class PourWaterActionBank(ActionBank):
+class PourWaterActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -113,8 +114,6 @@ class PourWaterActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -130,8 +129,6 @@ class PourWaterActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -147,7 +144,6 @@ class PourWaterActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -204,7 +200,6 @@ class PourWaterActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/_other_tasks/sample_loading/action_bank.py
+++ b/robosynchallenge/tasks/_other_tasks/sample_loading/action_bank.py
@@ -41,12 +41,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ...atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["SampleLoadingActionBank"]
 
 
-class SampleLoadingActionBank(ActionBank):
+class SampleLoadingActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -150,8 +151,6 @@ class SampleLoadingActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -189,8 +188,6 @@ class SampleLoadingActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -228,7 +225,6 @@ class SampleLoadingActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -285,7 +281,6 @@ class SampleLoadingActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/atomic_edge_replay.py
+++ b/robosynchallenge/tasks/atomic_edge_replay.py
@@ -1,0 +1,413 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Shared L1 atomic edge replay helpers for RoboSynChallenge ActionBanks."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import numpy as np
+import torch
+
+from embodichain.lab.gym.envs.action_bank.configurable_action import (
+    ActionBank,
+    get_func_tag,
+    tag_edge,
+    tag_node,
+)
+from embodichain.lab.sim.planners import MotionGenCfg, MotionGenerator, ToppraPlannerCfg
+from embodichain.utils import logger
+
+
+__all__ = ["AtomicEdgeReplayActionBankMixin"]
+
+
+class AtomicEdgeReplayActionBankMixin(ActionBank):
+    """Replay RoboSyn joint edges through EmbodiChain atomic ``MoveJoints``."""
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        AtomicEdgeReplayActionBankMixin._register_atomic_replay_edges(cls)
+
+    @staticmethod
+    def _register_atomic_replay_edges(action_bank_cls: type) -> None:
+        edge_functions = get_func_tag("edge").functions.setdefault(
+            action_bank_cls.__name__, {}
+        )
+        node_functions = get_func_tag("node").functions.setdefault(
+            action_bank_cls.__name__, {}
+        )
+
+        for func_name in (
+            "execute_open",
+            "execute_close",
+            "plan_trajectory",
+            "stand_still",
+        ):
+            edge_functions[func_name] = getattr(
+                AtomicEdgeReplayActionBankMixin, func_name
+            )
+
+        for func_name in ("execute_open", "execute_close"):
+            node_functions[func_name] = getattr(
+                AtomicEdgeReplayActionBankMixin, func_name
+            )
+
+    @staticmethod
+    @tag_edge
+    @tag_node
+    def execute_open(
+        env,
+        return_action: bool = False,
+        control_part: str | None = None,
+        **kwargs: Any,
+    ):
+        return AtomicEdgeReplayActionBankMixin._execute_gripper_replay(
+            env,
+            func_name="execute_open",
+            return_action=return_action,
+            control_part=control_part,
+            **kwargs,
+        )
+
+    @staticmethod
+    @tag_edge
+    @tag_node
+    def execute_close(
+        env,
+        return_action: bool = False,
+        control_part: str | None = None,
+        **kwargs: Any,
+    ):
+        return AtomicEdgeReplayActionBankMixin._execute_gripper_replay(
+            env,
+            func_name="execute_close",
+            return_action=return_action,
+            control_part=control_part,
+            **kwargs,
+        )
+
+    @staticmethod
+    @tag_edge
+    def plan_trajectory(
+        env,
+        agent_uid: str,
+        keypose_names: List[str],
+        duration: int,
+        edge_name: str = "",
+    ) -> np.ndarray:
+        keyposes = [
+            AtomicEdgeReplayActionBankMixin._to_qpos_tensor(
+                env.affordance_datas[keypose_name], device=env.robot.device
+            )
+            for keypose_name in keypose_names
+        ]
+
+        if all(
+            torch.linalg.norm(former - latter).sum() <= 1e-3
+            for former, latter in zip(keyposes, keyposes[1:])
+        ):
+            logger.log_warning(
+                "Applying atomic replay plan_trajectory to very close qpos values. "
+                "Using stand_still."
+            )
+            return AtomicEdgeReplayActionBankMixin.stand_still(
+                env,
+                agent_uid,
+                keypose_names,
+                duration,
+            )
+
+        segment_durations = AtomicEdgeReplayActionBankMixin._split_duration(
+            duration, len(keyposes) - 1
+        )
+        action = AtomicEdgeReplayActionBankMixin._make_move_joints_action(
+            env,
+            control_part=agent_uid,
+            sample_interval=segment_durations[0],
+        )
+        state = AtomicEdgeReplayActionBankMixin._make_world_state(
+            env, action.joint_ids, keyposes[0]
+        )
+
+        local_segments = []
+        for target_qpos, segment_duration in zip(keyposes[1:], segment_durations):
+            action.cfg.sample_interval = segment_duration
+            result = action.execute(
+                AtomicEdgeReplayActionBankMixin._joint_position_target(target_qpos),
+                state,
+            )
+            if not result.success:
+                logger.log_warning(
+                    f"Atomic MoveJoints failed for edge '{edge_name}' on {agent_uid}. "
+                    "Using stand_still fallback."
+                )
+                return AtomicEdgeReplayActionBankMixin.stand_still(
+                    env,
+                    agent_uid,
+                    keypose_names,
+                    duration,
+                )
+            local_segments.append(result.trajectory[:, :, action.joint_ids])
+            state = result.next_state
+
+        return torch.cat(local_segments, dim=1)[0].detach().cpu().numpy().T
+
+    @staticmethod
+    @tag_edge
+    def stand_still(
+        env,
+        agent_uid: str,
+        keypose_names: List[str],
+        duration: int,
+    ) -> np.ndarray:
+        start_qpos = AtomicEdgeReplayActionBankMixin._to_qpos_tensor(
+            env.affordance_datas[keypose_names[0]], device=env.robot.device
+        )
+        action = AtomicEdgeReplayActionBankMixin._make_move_joints_action(
+            env,
+            control_part=agent_uid,
+            sample_interval=max(int(duration), 1),
+        )
+        state = AtomicEdgeReplayActionBankMixin._make_world_state(
+            env, action.joint_ids, start_qpos
+        )
+        result = action.execute(
+            AtomicEdgeReplayActionBankMixin._joint_position_target(start_qpos), state
+        )
+        if not result.success:
+            logger.log_warning(
+                f"Atomic MoveJoints failed for stand_still on {agent_uid}. "
+                "Using repeated qpos fallback."
+            )
+            return start_qpos.unsqueeze(1).repeat(1, max(int(duration), 1)).cpu().numpy()
+        return result.trajectory[0, :, action.joint_ids].detach().cpu().numpy().T
+
+    @staticmethod
+    def _execute_gripper_replay(
+        env,
+        *,
+        func_name: str,
+        return_action: bool,
+        control_part: str | None,
+        **kwargs: Any,
+    ):
+        if not return_action:
+            return True
+        if control_part is None:
+            logger.log_error(
+                f"Atomic replay {func_name} requires explicit control_part in action_config.",
+                ValueError,
+            )
+
+        duration = max(int(kwargs.get("duration", 1)), 1)
+        original_kwargs = dict(kwargs)
+        original_kwargs.pop("duration", None)
+        original_qpos = AtomicEdgeReplayActionBankMixin._call_original_gripper_func(
+            env,
+            func_name=func_name,
+            control_part=control_part,
+            duration=duration,
+            **original_kwargs,
+        )
+        if original_qpos.ndim == 1:
+            original_qpos = original_qpos.reshape(1, -1)
+        if original_qpos.ndim != 2:
+            logger.log_error(
+                f"{func_name} must produce a 2D gripper trajectory, "
+                f"but got shape {original_qpos.shape}.",
+                ValueError,
+            )
+
+        waypoints = torch.as_tensor(
+            original_qpos.T,
+            dtype=torch.float32,
+            device=env.robot.device,
+        )
+        if waypoints.ndim == 1:
+            waypoints = waypoints.unsqueeze(-1)
+        if waypoints.shape[0] == 0:
+            logger.log_error(f"{func_name} produced an empty gripper trajectory.")
+
+        action = AtomicEdgeReplayActionBankMixin._make_move_joints_action(
+            env,
+            control_part=control_part,
+            sample_interval=max(waypoints.shape[0], 1),
+        )
+        waypoints = torch.stack(
+            [
+                AtomicEdgeReplayActionBankMixin._match_qpos_dim(
+                    waypoint, len(action.joint_ids)
+                )
+                for waypoint in waypoints
+            ],
+            dim=0,
+        )
+        state = AtomicEdgeReplayActionBankMixin._make_world_state(
+            env, action.joint_ids, waypoints[0]
+        )
+
+        local_segments = [
+            waypoints[:1].unsqueeze(0).repeat(action.n_envs, 1, 1)
+        ]
+        for target_qpos in waypoints[1:]:
+            action.cfg.sample_interval = 2
+            result = action.execute(
+                AtomicEdgeReplayActionBankMixin._joint_position_target(target_qpos),
+                state,
+            )
+            if not result.success:
+                logger.log_warning(
+                    f"Atomic MoveJoints failed for {control_part} {func_name}. "
+                    "Using original gripper qpos."
+                )
+                return original_qpos
+            local_segments.append(result.trajectory[:, -1:, action.joint_ids])
+            state = result.next_state
+
+        local_traj = torch.cat(local_segments, dim=1)
+        return local_traj[0, :, : original_qpos.shape[0]].detach().cpu().numpy().T
+
+    @staticmethod
+    def _call_original_gripper_func(
+        env,
+        *,
+        func_name: str,
+        control_part: str,
+        duration: int,
+        **kwargs: Any,
+    ) -> np.ndarray:
+        action_bank_cls = env.action_bank.__class__
+        for cls in action_bank_cls.mro():
+            if cls is AtomicEdgeReplayActionBankMixin:
+                continue
+            if not issubclass(cls, ActionBank):
+                continue
+            func = cls.__dict__.get(func_name)
+            if func is None:
+                continue
+            if isinstance(func, staticmethod):
+                func = func.__func__
+            ret = func(
+                env,
+                return_action=True,
+                control_part=control_part,
+                duration=duration,
+                **kwargs,
+            )
+            if isinstance(ret, torch.Tensor):
+                ret = ret.detach().cpu().numpy()
+            return np.asarray(ret, dtype=np.float32)
+
+        logger.log_error(
+            f"Cannot find original RoboSyn {func_name} implementation for "
+            f"{action_bank_cls.__name__}.",
+            RuntimeError,
+        )
+        raise AssertionError("unreachable")
+
+    @staticmethod
+    def _make_move_joints_action(env, *, control_part: str, sample_interval: int):
+        MoveJoints, MoveJointsCfg = AtomicEdgeReplayActionBankMixin._move_joints_types()
+        return MoveJoints(
+            AtomicEdgeReplayActionBankMixin._get_motion_generator(env),
+            MoveJointsCfg(
+                name=f"atomic_replay_{control_part}",
+                control_part=control_part,
+                sample_interval=max(int(sample_interval), 1),
+            ),
+        )
+
+    @staticmethod
+    def _get_motion_generator(env) -> MotionGenerator:
+        attr_name = "_robosyn_atomic_edge_replay_motion_generator"
+        motion_generator = getattr(env, attr_name, None)
+        if motion_generator is None:
+            motion_generator = MotionGenerator(
+                cfg=MotionGenCfg(planner_cfg=ToppraPlannerCfg(robot_uid=env.robot.uid))
+            )
+            setattr(env, attr_name, motion_generator)
+        return motion_generator
+
+    @staticmethod
+    def _make_world_state(env, joint_ids, start_qpos: torch.Tensor):
+        WorldState = AtomicEdgeReplayActionBankMixin._world_state_type()
+        full_qpos = env.robot.get_qpos().clone().to(
+            device=env.robot.device, dtype=torch.float32
+        )
+        if full_qpos.ndim == 1:
+            full_qpos = full_qpos.unsqueeze(0)
+        start_qpos = AtomicEdgeReplayActionBankMixin._match_qpos_dim(
+            start_qpos, len(joint_ids)
+        )
+        full_qpos[:, joint_ids] = start_qpos.unsqueeze(0).repeat(full_qpos.shape[0], 1)
+        return WorldState(last_qpos=full_qpos)
+
+    @staticmethod
+    def _to_qpos_tensor(qpos: Any, *, device: torch.device) -> torch.Tensor:
+        qpos_tensor = torch.as_tensor(qpos, dtype=torch.float32, device=device)
+        if qpos_tensor.ndim > 1:
+            qpos_tensor = qpos_tensor.reshape(-1, qpos_tensor.shape[-1])[0]
+        return qpos_tensor.reshape(-1)
+
+    @staticmethod
+    def _match_qpos_dim(qpos: torch.Tensor, dim: int) -> torch.Tensor:
+        qpos = qpos.reshape(-1)
+        if qpos.shape[-1] == dim:
+            return qpos
+        if qpos.shape[-1] == 1:
+            return qpos.repeat(dim)
+        logger.log_error(
+            f"Atomic replay qpos dim {qpos.shape[-1]} does not match control dim {dim}.",
+            ValueError,
+        )
+        raise AssertionError("unreachable")
+
+    @staticmethod
+    def _split_duration(duration: int, n_segments: int) -> list[int]:
+        if n_segments < 1:
+            logger.log_error("Atomic replay requires at least one trajectory segment.")
+        duration = max(int(duration), 1)
+        base_duration = duration // n_segments
+        remainder = duration % n_segments
+        segment_durations = [
+            base_duration + (1 if idx < remainder else 0)
+            for idx in range(n_segments)
+        ]
+        if any(segment_duration < 1 for segment_duration in segment_durations):
+            logger.log_error(
+                f"Cannot split duration {duration} over {n_segments} segments."
+            )
+        return segment_durations
+
+    @staticmethod
+    def _move_joints_types():
+        from embodichain.lab.sim.atomic_actions.actions import MoveJoints, MoveJointsCfg
+
+        return MoveJoints, MoveJointsCfg
+
+    @staticmethod
+    def _joint_position_target(qpos: torch.Tensor):
+        from embodichain.lab.sim.atomic_actions.core import JointPositionTarget
+
+        return JointPositionTarget(qpos=qpos)
+
+    @staticmethod
+    def _world_state_type():
+        from embodichain.lab.sim.atomic_actions.core import WorldState
+
+        return WorldState

--- a/robosynchallenge/tasks/atomic_edge_replay.py
+++ b/robosynchallenge/tasks/atomic_edge_replay.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-"""Shared L1 atomic edge replay helpers for RoboSynChallenge ActionBanks."""
+"""Shared atomic edge replay helpers for RoboSynChallenge ActionBanks."""
 
 from __future__ import annotations
 
@@ -33,7 +33,10 @@ from embodichain.lab.sim.planners import MotionGenCfg, MotionGenerator, ToppraPl
 from embodichain.utils import logger
 
 
-__all__ = ["AtomicEdgeReplayActionBankMixin"]
+__all__ = [
+    "AtomicEdgeReplayActionBankMixin",
+    "ExplicitTcpAtomicReplayActionBankMixin",
+]
 
 
 class AtomicEdgeReplayActionBankMixin(ActionBank):
@@ -411,3 +414,148 @@ class AtomicEdgeReplayActionBankMixin(ActionBank):
         from embodichain.lab.sim.atomic_actions.core import WorldState
 
         return WorldState
+
+
+class ExplicitTcpAtomicReplayActionBankMixin(AtomicEdgeReplayActionBankMixin):
+    """Replay arm edges through explicit TCP targets using ``MoveEndEffector``.
+
+    This L2 helper keeps RoboSyn's task-specific keypose builders intact. It
+    converts the generated qpos keyposes to TCP poses with FK, then asks
+    EmbodiChain's ``MoveEndEffector`` atomic action to replay each arm edge.
+    Gripper edges still come from the L1 ``MoveJoints`` replay path.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        ExplicitTcpAtomicReplayActionBankMixin._register_tcp_replay_edges(cls)
+
+    @staticmethod
+    def _register_tcp_replay_edges(action_bank_cls: type) -> None:
+        edge_functions = get_func_tag("edge").functions.setdefault(
+            action_bank_cls.__name__, {}
+        )
+        edge_functions["plan_trajectory"] = getattr(
+            ExplicitTcpAtomicReplayActionBankMixin, "plan_trajectory"
+        )
+
+    @staticmethod
+    @tag_edge
+    def plan_trajectory(
+        env,
+        agent_uid: str,
+        keypose_names: List[str],
+        duration: int,
+        edge_name: str = "",
+    ) -> np.ndarray:
+        keyposes = [
+            ExplicitTcpAtomicReplayActionBankMixin._to_qpos_tensor(
+                env.affordance_datas[keypose_name], device=env.robot.device
+            )
+            for keypose_name in keypose_names
+        ]
+
+        if all(
+            torch.linalg.norm(former - latter).sum() <= 1e-3
+            for former, latter in zip(keyposes, keyposes[1:])
+        ):
+            logger.log_warning(
+                "Applying explicit TCP replay plan_trajectory to very close qpos "
+                "values. Using stand_still."
+            )
+            return AtomicEdgeReplayActionBankMixin.stand_still(
+                env,
+                agent_uid,
+                keypose_names,
+                duration,
+            )
+
+        tcp_poses = [
+            ExplicitTcpAtomicReplayActionBankMixin._compute_tcp_pose_from_qpos(
+                env, agent_uid, keypose
+            )
+            for keypose in keyposes
+        ]
+        segment_durations = ExplicitTcpAtomicReplayActionBankMixin._split_duration(
+            duration, len(keyposes) - 1
+        )
+        action = ExplicitTcpAtomicReplayActionBankMixin._make_move_end_effector_action(
+            env,
+            control_part=agent_uid,
+            sample_interval=segment_durations[0],
+        )
+        state = ExplicitTcpAtomicReplayActionBankMixin._make_world_state(
+            env, action.arm_joint_ids, keyposes[0]
+        )
+
+        local_segments = []
+        for target_pose, segment_duration in zip(tcp_poses[1:], segment_durations):
+            action.cfg.sample_interval = segment_duration
+            result = action.execute(
+                ExplicitTcpAtomicReplayActionBankMixin._end_effector_pose_target(
+                    target_pose
+                ),
+                state,
+            )
+            if not result.success:
+                logger.log_warning(
+                    f"Atomic MoveEndEffector failed for edge '{edge_name}' on "
+                    f"{agent_uid}. Falling back to L1 MoveJoints replay."
+                )
+                return AtomicEdgeReplayActionBankMixin.plan_trajectory(
+                    env,
+                    agent_uid,
+                    keypose_names,
+                    duration,
+                    edge_name=edge_name,
+                )
+            local_segments.append(result.trajectory[:, :, action.arm_joint_ids])
+            state = result.next_state
+
+        return torch.cat(local_segments, dim=1)[0].detach().cpu().numpy().T
+
+    @staticmethod
+    def _compute_tcp_pose_from_qpos(
+        env, control_part: str, qpos: torch.Tensor
+    ) -> torch.Tensor:
+        n_envs = env.robot.get_qpos().shape[0]
+        qpos = ExplicitTcpAtomicReplayActionBankMixin._match_qpos_dim(
+            qpos, len(env.robot.get_joint_ids(name=control_part))
+        )
+        qpos = qpos.unsqueeze(0).repeat(n_envs, 1)
+        return env.robot.compute_fk(
+            qpos=qpos,
+            name=control_part,
+            to_matrix=True,
+        ).to(device=env.robot.device, dtype=torch.float32)
+
+    @staticmethod
+    def _make_move_end_effector_action(
+        env, *, control_part: str, sample_interval: int
+    ):
+        (
+            MoveEndEffector,
+            MoveEndEffectorCfg,
+        ) = ExplicitTcpAtomicReplayActionBankMixin._move_end_effector_types()
+        return MoveEndEffector(
+            ExplicitTcpAtomicReplayActionBankMixin._get_motion_generator(env),
+            MoveEndEffectorCfg(
+                name=f"explicit_tcp_replay_{control_part}",
+                control_part=control_part,
+                sample_interval=max(int(sample_interval), 1),
+            ),
+        )
+
+    @staticmethod
+    def _move_end_effector_types():
+        from embodichain.lab.sim.atomic_actions.actions import (
+            MoveEndEffector,
+            MoveEndEffectorCfg,
+        )
+
+        return MoveEndEffector, MoveEndEffectorCfg
+
+    @staticmethod
+    def _end_effector_pose_target(xpos: torch.Tensor):
+        from embodichain.lab.sim.atomic_actions.core import EndEffectorPoseTarget
+
+        return EndEffectorPoseTarget(xpos=xpos)

--- a/robosynchallenge/tasks/click_bell/action_bank.py
+++ b/robosynchallenge/tasks/click_bell/action_bank.py
@@ -41,12 +41,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["ClickBellActionBank"]
 
 
-class ClickBellActionBank(ActionBank):
+class ClickBellActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -125,8 +126,6 @@ class ClickBellActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -142,8 +141,6 @@ class ClickBellActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -159,7 +156,6 @@ class ClickBellActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -216,7 +212,6 @@ class ClickBellActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/drawer_open_place/action_bank.py
+++ b/robosynchallenge/tasks/drawer_open_place/action_bank.py
@@ -5,7 +5,6 @@ from typing import List
 
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
-    tag_edge,
     tag_node,
 )
 from embodichain.lab.gym.utils.misc import resolve_env_params
@@ -19,11 +18,12 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 __all__ = ["DrawerOpenPlaceActionBank"]
 
 
-class DrawerOpenPlaceActionBank(ActionBank):
+class DrawerOpenPlaceActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     """Small task-specific action bank for DrawerOpenPlace.
 
     The geometric recipe is intentionally kept in action_config.json. This class
@@ -149,8 +149,6 @@ class DrawerOpenPlaceActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_node
-    @tag_edge
     @resolve_env_params
     def execute_open(
         env,
@@ -187,8 +185,6 @@ class DrawerOpenPlaceActionBank(ActionBank):
         )
 
     @staticmethod
-    @tag_node
-    @tag_edge
     @resolve_env_params
     def execute_close(
         env,
@@ -233,7 +229,6 @@ class DrawerOpenPlaceActionBank(ActionBank):
         )
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -285,7 +280,6 @@ class DrawerOpenPlaceActionBank(ActionBank):
         return positions.T.astype(np.float32)
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/handle_basket/action_bank.py
+++ b/robosynchallenge/tasks/handle_basket/action_bank.py
@@ -24,7 +24,6 @@ import torch
 
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
-    tag_edge,
     tag_node,
 )
 from embodichain.lab.gym.utils.misc import (
@@ -43,11 +42,12 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 __all__ = ["HandleBasketActionBank"]
 
 
-class HandleBasketActionBank(ActionBank):
+class HandleBasketActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -65,8 +65,6 @@ class HandleBasketActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_open(env, return_action: bool = False, limit: float = 1.0, **kwargs):
         if return_action:
             duration = kwargs.get("duration", 1)
@@ -80,8 +78,6 @@ class HandleBasketActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, limit: float = 1.0, **kwargs):
         if return_action:
             duration = kwargs.get("duration", 1)
@@ -165,7 +161,6 @@ class HandleBasketActionBank(ActionBank):
 
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -221,7 +216,6 @@ class HandleBasketActionBank(ActionBank):
 
             return ret.positions.numpy().T
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/item_assembly/action_bank.py
+++ b/robosynchallenge/tasks/item_assembly/action_bank.py
@@ -41,12 +41,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["ItemAssemblyActionBank"]
 
 
-class ItemAssemblyActionBank(ActionBank):
+class ItemAssemblyActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
 
     @staticmethod
     @tag_node
@@ -109,8 +110,6 @@ class ItemAssemblyActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -126,8 +125,6 @@ class ItemAssemblyActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -143,7 +140,6 @@ class ItemAssemblyActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -200,7 +196,6 @@ class ItemAssemblyActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/items_handover/action_bank.py
+++ b/robosynchallenge/tasks/items_handover/action_bank.py
@@ -11,7 +11,6 @@ from typing import Dict, Tuple, Union, List, Any, Optional, Callable
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
     tag_node,
-    tag_edge,
 )
 
 from embodichain.lab.gym.utils.misc import (
@@ -32,11 +31,12 @@ from embodichain.lab.sim.planners import (
 )
 
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 __all__ = ["ItemsHandoverActionBank"]
 
 
-class ItemsHandoverActionBank(ActionBank):
+class ItemsHandoverActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
 
     @staticmethod
     @tag_node
@@ -109,8 +109,6 @@ class ItemsHandoverActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -148,8 +146,6 @@ class ItemsHandoverActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -187,7 +183,6 @@ class ItemsHandoverActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -244,7 +239,6 @@ class ItemsHandoverActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/manipulate_pipette/action_bank.py
+++ b/robosynchallenge/tasks/manipulate_pipette/action_bank.py
@@ -21,7 +21,6 @@ from typing import Dict, List
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
     tag_node,
-    tag_edge,
 )
 
 from embodichain.lab.gym.utils.misc import (
@@ -41,12 +40,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["ManipulatePipetteActionBank"]
 
 
-class ManipulatePipetteActionBank(ActionBank):
+class ManipulatePipetteActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
 
     @staticmethod
     @tag_node
@@ -142,8 +142,6 @@ class ManipulatePipetteActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -181,8 +179,6 @@ class ManipulatePipetteActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -220,7 +216,6 @@ class ManipulatePipetteActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -277,7 +272,6 @@ class ManipulatePipetteActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/mixer_operating/action_bank.py
+++ b/robosynchallenge/tasks/mixer_operating/action_bank.py
@@ -22,7 +22,6 @@ from typing import List
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
     tag_node,
-    tag_edge,
 )
 
 from embodichain.lab.gym.utils.misc import resolve_env_params, mul_linear_expand
@@ -37,12 +36,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["MixerOperatingActionBank"]
 
 
-class MixerOperatingActionBank(ActionBank):
+class MixerOperatingActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -136,8 +136,6 @@ class MixerOperatingActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
             duration = kwargs.get("duration", 1)
@@ -174,8 +172,6 @@ class MixerOperatingActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
         if return_action:
             duration = kwargs.get("duration", 1)
@@ -212,7 +208,6 @@ class MixerOperatingActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -269,7 +264,6 @@ class MixerOperatingActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/sample_loading/action_bank.py
+++ b/robosynchallenge/tasks/sample_loading/action_bank.py
@@ -21,7 +21,6 @@ from typing import Dict, List
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
     tag_node,
-    tag_edge,
 )
 
 from embodichain.lab.gym.utils.misc import (
@@ -41,12 +40,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["SampleLoadingActionBank"]
 
 
-class SampleLoadingActionBank(ActionBank):
+class SampleLoadingActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -139,8 +139,6 @@ class SampleLoadingActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -178,8 +176,6 @@ class SampleLoadingActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -217,7 +213,6 @@ class SampleLoadingActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -274,7 +269,6 @@ class SampleLoadingActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/table_rearrangement/action_bank.py
+++ b/robosynchallenge/tasks/table_rearrangement/action_bank.py
@@ -41,13 +41,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
-from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
+from ..atomic_edge_replay import ExplicitTcpAtomicReplayActionBankMixin
 
 
 __all__ = ["TableRearrangementActionBank"]
 
 
-class TableRearrangementActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
+class TableRearrangementActionBank(ExplicitTcpAtomicReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params

--- a/robosynchallenge/tasks/table_rearrangement/action_bank.py
+++ b/robosynchallenge/tasks/table_rearrangement/action_bank.py
@@ -22,7 +22,6 @@ from embodichain.lab.sim.planners.motion_generator import MotionGenerator
 from embodichain.lab.gym.envs.action_bank.configurable_action import (
     ActionBank,
     tag_node,
-    tag_edge,
 )
 
 from embodichain.lab.gym.utils.misc import (
@@ -42,12 +41,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["TableRearrangementActionBank"]
 
 
-class TableRearrangementActionBank(ActionBank):
+class TableRearrangementActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -65,8 +65,6 @@ class TableRearrangementActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, limit: float = 0.05, **kwargs):
         if return_action:
@@ -82,8 +80,6 @@ class TableRearrangementActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, limit: float = 0.05, **kwargs):
 
         if return_action:
@@ -99,7 +95,6 @@ class TableRearrangementActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -157,7 +152,6 @@ class TableRearrangementActionBank(ActionBank):
 
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/robosynchallenge/tasks/water_pouring/action_bank.py
+++ b/robosynchallenge/tasks/water_pouring/action_bank.py
@@ -41,12 +41,13 @@ from embodichain.lab.sim.planners import (
     ToppraPlannerCfg,
 )
 from embodichain.utils import logger
+from ..atomic_edge_replay import AtomicEdgeReplayActionBankMixin
 
 
 __all__ = ["WaterPouringActionBank"]
 
 
-class WaterPouringActionBank(ActionBank):
+class WaterPouringActionBank(AtomicEdgeReplayActionBankMixin, ActionBank):
     @staticmethod
     @tag_node
     @resolve_env_params
@@ -113,8 +114,6 @@ class WaterPouringActionBank(ActionBank):
         return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     # TODO: Got the dimension from the scope
     def execute_open(env, return_action: bool = False, **kwargs):
         if return_action:
@@ -130,8 +129,6 @@ class WaterPouringActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
-    @tag_node
     def execute_close(env, return_action: bool = False, **kwargs):
 
         if return_action:
@@ -147,7 +144,6 @@ class WaterPouringActionBank(ActionBank):
             return True
 
     @staticmethod
-    @tag_edge
     def plan_trajectory(
         env,
         agent_uid: str,
@@ -204,7 +200,6 @@ class WaterPouringActionBank(ActionBank):
             return ret.positions.numpy().T
 
     @staticmethod
-    @tag_edge
     def stand_still(
         env,
         agent_uid: str,

--- a/tests/test_atomic_edge_replay.py
+++ b/tests/test_atomic_edge_replay.py
@@ -1,0 +1,361 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from gymnasium.envs.registration import registry
+
+from embodichain.data import get_data_path
+from embodichain.lab.gym.envs.action_bank.configurable_action import (
+    ActionBank,
+    get_func_tag,
+)
+from robosynchallenge.tasks.atomic_edge_replay import AtomicEdgeReplayActionBankMixin
+
+
+TASK_ACTION_BANKS = [
+    (
+        "table_rearrangement",
+        "configs/table_rearrangement/action_config.json",
+        "robosynchallenge.tasks.table_rearrangement.action_bank",
+        "TableRearrangementActionBank",
+    ),
+    (
+        "click_bell",
+        "configs/click_bell/action_config.json",
+        "robosynchallenge.tasks.click_bell.action_bank",
+        "ClickBellActionBank",
+    ),
+    (
+        "drawer_open_place",
+        "configs/drawer_open_place/action_config.json",
+        "robosynchallenge.tasks.drawer_open_place.action_bank",
+        "DrawerOpenPlaceActionBank",
+    ),
+    (
+        "handle_basket",
+        "configs/handle_basket/action_config.json",
+        "robosynchallenge.tasks.handle_basket.action_bank",
+        "HandleBasketActionBank",
+    ),
+    (
+        "item_assembly",
+        "configs/item_assembly/action_config.json",
+        "robosynchallenge.tasks.item_assembly.action_bank",
+        "ItemAssemblyActionBank",
+    ),
+    (
+        "items_handover",
+        "configs/items_handover/action_config.json",
+        "robosynchallenge.tasks.items_handover.action_bank",
+        "ItemsHandoverActionBank",
+    ),
+    (
+        "manipulate_pipette",
+        "configs/manipulate_pipette/action_config.json",
+        "robosynchallenge.tasks.manipulate_pipette.action_bank",
+        "ManipulatePipetteActionBank",
+    ),
+    (
+        "mixer_operating",
+        "configs/mixer_operating/action_config.json",
+        "robosynchallenge.tasks.mixer_operating.action_bank",
+        "MixerOperatingActionBank",
+    ),
+    (
+        "sample_loading",
+        "configs/sample_loading/action_config.json",
+        "robosynchallenge.tasks.sample_loading.action_bank",
+        "SampleLoadingActionBank",
+    ),
+    (
+        "water_pouring",
+        "configs/water_pouring/action_config.json",
+        "robosynchallenge.tasks.water_pouring.action_bank",
+        "WaterPouringActionBank",
+    ),
+    (
+        "open_pan",
+        "configs/other_tasks/open_pan/action_config.json",
+        "robosynchallenge.tasks._other_tasks.open_pan.action_bank",
+        "OpenPanPickandPlaceActionBank",
+    ),
+    (
+        "manipulate_pipette_two_beaker",
+        "configs/other_tasks/manipulate_pipette_two_beaker/action_config.json",
+        "robosynchallenge.tasks._other_tasks.manipulate_pipette_two_beaker.action_bank",
+        "ManipulatePipetteTwoBeakerActionBank",
+    ),
+    (
+        "pour_water",
+        "configs/other_tasks/pour_water/action_config.json",
+        "robosynchallenge.tasks._other_tasks.pour_water.action_bank",
+        "PourWaterActionBank",
+    ),
+    (
+        "sample_loading-v1",
+        "configs/other_tasks/sample_loading/action_config.json",
+        "robosynchallenge.tasks._other_tasks.sample_loading.action_bank",
+        "SampleLoadingActionBank",
+    ),
+]
+
+
+COMMON_EDGE_NAMES = (
+    "execute_open",
+    "execute_close",
+    "plan_trajectory",
+    "stand_still",
+)
+
+CONFIG_ROOT = Path("configs")
+LEGACY_ABSOLUTE_PREFIXES = (
+    "/root/workspace/RoboSynChallenge",
+    "/root/workspace/outputs_pan",
+    "/root/workspace/embodichain",
+    "/home/dex/EmbodiChain/RoboSynChallenge",
+)
+OTHER_TASK_ENV_IDS = (
+    "OpenPanPickAndPlaceEnv-v1",
+    "ManipulatePipetteTwoBeaker",
+)
+
+
+def _read_json(path: str) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def _walk_json_values(value):
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk_json_values(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_json_values(child)
+    else:
+        yield value
+
+
+def _collect_action_bank_functions(action_bank_cls: type) -> tuple[dict, dict]:
+    node_funcs = {}
+    edge_funcs = {}
+    action_bank_classes = [
+        cls for cls in reversed(action_bank_cls.mro()) if issubclass(cls, ActionBank)
+    ]
+    for cls in action_bank_classes:
+        node_funcs.update(get_func_tag("node").functions.get(cls.__name__, {}))
+        edge_funcs.update(get_func_tag("edge").functions.get(cls.__name__, {}))
+    return node_funcs, edge_funcs
+
+
+def test_target_action_configs_load_and_gripper_edges_have_control_part() -> None:
+    missing_or_invalid = []
+    for label, config_path, _, _ in TASK_ACTION_BANKS:
+        action_config = _read_json(config_path)
+        assert action_config["scope"]
+        assert action_config["node"]
+        assert action_config["edge"]
+
+        for scope, edges in action_config["edge"].items():
+            for edge in edges:
+                edge_label, spec = next(iter(edge.items()))
+                if spec.get("name") not in {"execute_open", "execute_close"}:
+                    continue
+                control_part = spec.get("kwargs", {}).get("control_part")
+                expected = scope if scope in {"left_eef", "right_eef"} else None
+                if control_part not in {"left_eef", "right_eef"}:
+                    missing_or_invalid.append((label, edge_label, control_part))
+                if expected is not None and control_part != expected:
+                    missing_or_invalid.append((label, edge_label, control_part))
+
+    assert missing_or_invalid == []
+
+
+def test_all_configs_load_and_do_not_use_legacy_absolute_paths() -> None:
+    offenders = []
+    for config_path in sorted(CONFIG_ROOT.glob("**/*.json")):
+        config = _read_json(str(config_path))
+        for value in _walk_json_values(config):
+            if not isinstance(value, str):
+                continue
+            if value.startswith(LEGACY_ABSOLUTE_PREFIXES):
+                offenders.append((str(config_path), value))
+
+    assert offenders == []
+
+
+def test_robosynchallenge_data_namespace_resolves_local_assets() -> None:
+    resolved = Path(get_data_path("RoboSynChallenge/assets/button/button.urdf"))
+
+    assert resolved.is_file()
+    assert resolved.name == "button.urdf"
+
+
+def test_embodichain_visual_material_runtime_shim_parses_shape_cfg() -> None:
+    from embodichain.lab.sim.shapes import ShapeCfg
+
+    shape_cfg = ShapeCfg.from_dict(
+        {
+            "shape_type": "Cube",
+            "size": [1.0, 1.0, 1.0],
+            "visual_material": {
+                "uid": "unit_test_material",
+                "base_color": [1.0, 1.0, 1.0, 1.0],
+            },
+        }
+    )
+
+    assert shape_cfg.visual_material.uid == "unit_test_material"
+
+
+def test_other_task_envs_are_registered() -> None:
+    import robosynchallenge.tasks  # noqa: F401
+
+    missing = [env_id for env_id in OTHER_TASK_ENV_IDS if env_id not in registry]
+
+    assert missing == []
+
+
+def test_configured_robosynchallenge_asset_paths_exist() -> None:
+    missing = []
+    for config_path in sorted(CONFIG_ROOT.glob("**/*.json")):
+        config = _read_json(str(config_path))
+        for value in _walk_json_values(config):
+            if not isinstance(value, str):
+                continue
+            if not value.startswith("RoboSynChallenge/"):
+                continue
+            resolved = Path(get_data_path(value))
+            if not resolved.exists():
+                missing.append((str(config_path), value))
+
+    assert missing == []
+
+
+def test_action_banks_parse_graphs_with_atomic_replay_common_edges() -> None:
+    for label, config_path, module_name, class_name in TASK_ACTION_BANKS:
+        module = importlib.import_module(module_name)
+        action_bank_cls = getattr(module, class_name)
+        action_bank = action_bank_cls(_read_json(config_path))
+
+        node_funcs, edge_funcs = _collect_action_bank_functions(action_bank_cls)
+        action_bank.parse_network(node_funcs, edge_funcs, vis_graph=False)
+
+        assert issubclass(action_bank_cls, AtomicEdgeReplayActionBankMixin), label
+        for func_name in COMMON_EDGE_NAMES:
+            assert edge_funcs[func_name] is getattr(
+                AtomicEdgeReplayActionBankMixin, func_name
+            ), (label, func_name)
+        assert node_funcs["execute_open"] is AtomicEdgeReplayActionBankMixin.execute_open
+        assert (
+            node_funcs["execute_close"]
+            is AtomicEdgeReplayActionBankMixin.execute_close
+        )
+
+
+def test_duration_split_preserves_total_length() -> None:
+    assert AtomicEdgeReplayActionBankMixin._split_duration(11, 3) == [4, 4, 3]
+
+
+def test_qpos_tensor_flattens_single_env_values() -> None:
+    qpos = AtomicEdgeReplayActionBankMixin._to_qpos_tensor(
+        torch.ones(1, 6),
+        device=torch.device("cpu"),
+    )
+
+    assert qpos.shape == (6,)
+    assert torch.allclose(qpos, torch.ones(6))
+
+
+def test_match_qpos_dim_broadcasts_scalar_gripper_target() -> None:
+    qpos = AtomicEdgeReplayActionBankMixin._match_qpos_dim(torch.tensor([0.05]), 2)
+
+    assert torch.allclose(qpos, torch.tensor([0.05, 0.05]))
+
+
+def test_gripper_replay_keeps_original_waypoints_and_control_part(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"sample_intervals": []}
+    original_qpos = np.array([[0.0, 0.5, 1.0]], dtype=np.float32)
+
+    def fake_original_func(env, *, func_name, control_part, duration, **kwargs):
+        calls["original"] = (func_name, control_part, duration)
+        return original_qpos
+
+    class FakeAction:
+        joint_ids = [13]
+        n_envs = 1
+
+        def __init__(self) -> None:
+            self.cfg = SimpleNamespace(sample_interval=0)
+
+        def execute(self, target, state):
+            calls["sample_intervals"].append(self.cfg.sample_interval)
+            full_trajectory = torch.zeros(1, 2, 14, dtype=torch.float32)
+            full_trajectory[:, -1, self.joint_ids] = target.qpos.reshape(1, 1)
+            return SimpleNamespace(
+                success=True,
+                trajectory=full_trajectory,
+                next_state=state,
+            )
+
+    def fake_make_action(env, *, control_part, sample_interval):
+        calls["action"] = (control_part, sample_interval)
+        return FakeAction()
+
+    def fake_make_world_state(env, joint_ids, start_qpos):
+        calls["world_state"] = (joint_ids, start_qpos.detach().cpu())
+        return object()
+
+    monkeypatch.setattr(
+        AtomicEdgeReplayActionBankMixin,
+        "_call_original_gripper_func",
+        staticmethod(fake_original_func),
+    )
+    monkeypatch.setattr(
+        AtomicEdgeReplayActionBankMixin,
+        "_make_move_joints_action",
+        staticmethod(fake_make_action),
+    )
+    monkeypatch.setattr(
+        AtomicEdgeReplayActionBankMixin,
+        "_make_world_state",
+        staticmethod(fake_make_world_state),
+    )
+    env = SimpleNamespace(robot=SimpleNamespace(device=torch.device("cpu")))
+
+    replay = AtomicEdgeReplayActionBankMixin._execute_gripper_replay(
+        env,
+        func_name="execute_close",
+        return_action=True,
+        control_part="right_eef",
+        duration=original_qpos.shape[1],
+    )
+
+    assert calls["original"] == ("execute_close", "right_eef", original_qpos.shape[1])
+    assert calls["action"] == ("right_eef", original_qpos.shape[1])
+    assert calls["world_state"][0] == [13]
+    assert calls["sample_intervals"] == [2, 2]
+    assert np.allclose(replay, original_qpos)

--- a/tests/test_atomic_edge_replay.py
+++ b/tests/test_atomic_edge_replay.py
@@ -32,6 +32,9 @@ from embodichain.lab.gym.envs.action_bank.configurable_action import (
     get_func_tag,
 )
 from robosynchallenge.tasks.atomic_edge_replay import AtomicEdgeReplayActionBankMixin
+from robosynchallenge.tasks.atomic_edge_replay import (
+    ExplicitTcpAtomicReplayActionBankMixin,
+)
 
 
 TASK_ACTION_BANKS = [
@@ -264,6 +267,11 @@ def test_action_banks_parse_graphs_with_atomic_replay_common_edges() -> None:
 
         assert issubclass(action_bank_cls, AtomicEdgeReplayActionBankMixin), label
         for func_name in COMMON_EDGE_NAMES:
+            if label == "table_rearrangement" and func_name == "plan_trajectory":
+                assert edge_funcs[func_name] is getattr(
+                    ExplicitTcpAtomicReplayActionBankMixin, func_name
+                ), (label, func_name)
+                continue
             assert edge_funcs[func_name] is getattr(
                 AtomicEdgeReplayActionBankMixin, func_name
             ), (label, func_name)
@@ -272,6 +280,116 @@ def test_action_banks_parse_graphs_with_atomic_replay_common_edges() -> None:
             node_funcs["execute_close"]
             is AtomicEdgeReplayActionBankMixin.execute_close
         )
+
+
+def test_table_rearrangement_uses_explicit_tcp_replay_for_arm_edges() -> None:
+    from robosynchallenge.tasks.table_rearrangement.action_bank import (
+        TableRearrangementActionBank,
+    )
+
+    _, edge_funcs = _collect_action_bank_functions(TableRearrangementActionBank)
+
+    assert issubclass(
+        TableRearrangementActionBank,
+        ExplicitTcpAtomicReplayActionBankMixin,
+    )
+    assert (
+        edge_funcs["plan_trajectory"]
+        is ExplicitTcpAtomicReplayActionBankMixin.plan_trajectory
+    )
+
+
+def test_explicit_tcp_replay_returns_local_arm_trajectory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    class FakeRobot:
+        device = torch.device("cpu")
+
+        def get_qpos(self):
+            return torch.zeros(1, 4, dtype=torch.float32)
+
+        def get_joint_ids(self, name):
+            assert name == "left_arm"
+            return [0, 1]
+
+    class FakeAction:
+        arm_joint_ids = [0, 1]
+
+        def __init__(self) -> None:
+            self.cfg = SimpleNamespace(sample_interval=0)
+
+        def execute(self, target, state):
+            calls.append((self.cfg.sample_interval, target.xpos[0, 0, 3].item()))
+            full_trajectory = torch.zeros(
+                1, self.cfg.sample_interval, 4, dtype=torch.float32
+            )
+            full_trajectory[:, :, 0] = target.xpos[0, 0, 3]
+            full_trajectory[:, :, 1] = target.xpos[0, 0, 3] + 10.0
+            return SimpleNamespace(
+                success=True,
+                trajectory=full_trajectory,
+                next_state=SimpleNamespace(last_qpos=full_trajectory[:, -1, :]),
+            )
+
+    def fake_compute_tcp_pose(env, control_part, qpos):
+        pose = torch.eye(4, dtype=torch.float32).unsqueeze(0)
+        pose[:, 0, 3] = qpos[0]
+        return pose
+
+    def fake_make_action(env, *, control_part, sample_interval):
+        assert control_part == "left_arm"
+        action = FakeAction()
+        action.cfg.sample_interval = sample_interval
+        return action
+
+    def fake_make_world_state(env, joint_ids, start_qpos):
+        assert joint_ids == [0, 1]
+        assert torch.allclose(start_qpos, torch.tensor([0.0, 0.5]))
+        return SimpleNamespace(last_qpos=torch.zeros(1, 4, dtype=torch.float32))
+
+    monkeypatch.setattr(
+        ExplicitTcpAtomicReplayActionBankMixin,
+        "_compute_tcp_pose_from_qpos",
+        staticmethod(fake_compute_tcp_pose),
+    )
+    monkeypatch.setattr(
+        ExplicitTcpAtomicReplayActionBankMixin,
+        "_make_move_end_effector_action",
+        staticmethod(fake_make_action),
+    )
+    monkeypatch.setattr(
+        ExplicitTcpAtomicReplayActionBankMixin,
+        "_make_world_state",
+        staticmethod(fake_make_world_state),
+    )
+    monkeypatch.setattr(
+        ExplicitTcpAtomicReplayActionBankMixin,
+        "_end_effector_pose_target",
+        staticmethod(lambda xpos: SimpleNamespace(xpos=xpos)),
+    )
+    env = SimpleNamespace(
+        robot=FakeRobot(),
+        affordance_datas={
+            "start": torch.tensor([0.0, 0.5]),
+            "middle": torch.tensor([1.0, 1.5]),
+            "end": torch.tensor([3.0, 3.5]),
+        },
+    )
+
+    replay = ExplicitTcpAtomicReplayActionBankMixin.plan_trajectory(
+        env,
+        agent_uid="left_arm",
+        keypose_names=["start", "middle", "end"],
+        duration=5,
+        edge_name="unit_test_edge",
+    )
+
+    assert calls == [(3, 1.0), (2, 3.0)]
+    assert replay.shape == (2, 5)
+    assert np.allclose(replay[0], [1.0, 1.0, 1.0, 3.0, 3.0])
+    assert np.allclose(replay[1], [11.0, 11.0, 11.0, 13.0, 13.0])
 
 
 def test_duration_split_preserves_total_length() -> None:


### PR DESCRIPTION
## Summary
- add L1 Atomic Edge Replay for 14 RoboSynChallenge action banks through EmbodiChain MoveJoints
- add explicit TCP atomic replay sample for table_rearrangement using MoveEndEffector for arm edges and MoveJoints for grippers
- preserve RoboSyn keypose graph, IK, sync graph, and task-specific keypose builders

## Validation
- python3 -m compileall -q robosynchallenge tests
- git diff --check
- PYTHONPATH=/home/dex/EmbodiChain/new_atomic_action:$PYTHONPATH MPLCONFIGDIR=/tmp/matplotlib-cache conda run -n embodichain040 python -m pytest tests/test_atomic_edge_replay.py -q
- table_rearrangement video smoke checked locally by Dex; no MoveEndEffector-to-MoveJoints fallback observed in the successful run
