### PR TITLE
fix: correct drawer open place drive config

### DIFF
--- a/configs/drawer_open_place/clear/gym_config.json
+++ b/configs/drawer_open_place/clear/gym_config.json
@@ -386,16 +386,16 @@
         },
         "drive_pros": {
             "stiffness": {
-                "LEFT_JOINT[7-8]": 600.0,
-                "RIGHT_JOINT[7-8]": 600.0
+                "left_joint[7-8]": 600.0,
+                "right_joint[7-8]": 600.0
             },
             "damping": {
-                "LEFT_JOINT[7-8]": 60.0,
-                "RIGHT_JOINT[7-8]": 60.0
+                "left_joint[7-8]": 60.0,
+                "right_joint[7-8]": 60.0
             },
             "max_effort": {
-                "LEFT_JOINT[7-8]": 6000.0,
-                "RIGHT_JOINT[7-8]": 6000.0
+                "left_joint[7-8]": 6000.0,
+                "right_joint[7-8]": 6000.0
             }
         }
     },
@@ -625,6 +625,7 @@
                 "dynamic_friction": 4.8
             },
             "drive_pros": {
+                "drive_type": "none",
                 "stiffness": 10.0,
                 "damping": 3.0
             }
@@ -643,6 +644,7 @@
                 "rest_offset": 0.00005
             },
             "drive_pros": {
+                "drive_type": "none",
                 "stiffness": 10.0,
                 "damping": 3.0
             }

--- a/configs/drawer_open_place/gym_config_random_test.json
+++ b/configs/drawer_open_place/gym_config_random_test.json
@@ -542,16 +542,16 @@
         },
         "drive_pros": {
             "stiffness": {
-                "LEFT_JOINT[7-8]": 600.0,
-                "RIGHT_JOINT[7-8]": 600.0
+                "left_joint[7-8]": 600.0,
+                "right_joint[7-8]": 600.0
             },
             "damping": {
-                "LEFT_JOINT[7-8]": 60.0,
-                "RIGHT_JOINT[7-8]": 60.0
+                "left_joint[7-8]": 60.0,
+                "right_joint[7-8]": 60.0
             },
             "max_effort": {
-                "LEFT_JOINT[7-8]": 6000.0,
-                "RIGHT_JOINT[7-8]": 6000.0
+                "left_joint[7-8]": 6000.0,
+                "right_joint[7-8]": 6000.0
             }
         }
     },

--- a/configs/drawer_open_place/random/gym_config.json
+++ b/configs/drawer_open_place/random/gym_config.json
@@ -516,16 +516,16 @@
         },
         "drive_pros": {
             "stiffness": {
-                "LEFT_JOINT[7-8]": 600.0,
-                "RIGHT_JOINT[7-8]": 600.0
+                "left_joint[7-8]": 600.0,
+                "right_joint[7-8]": 600.0
             },
             "damping": {
-                "LEFT_JOINT[7-8]": 60.0,
-                "RIGHT_JOINT[7-8]": 60.0
+                "left_joint[7-8]": 60.0,
+                "right_joint[7-8]": 60.0
             },
             "max_effort": {
-                "LEFT_JOINT[7-8]": 6000.0,
-                "RIGHT_JOINT[7-8]": 6000.0
+                "left_joint[7-8]": 6000.0,
+                "right_joint[7-8]": 6000.0
             }
         }
     },
@@ -769,6 +769,7 @@
                 "dynamic_friction": 4.8
             },
             "drive_pros": {
+                "drive_type": "none",
                 "stiffness": 10.0,
                 "damping": 3.0
             }

--- a/robosynchallenge/tasks/drawer_open_place/action_bank.py
+++ b/robosynchallenge/tasks/drawer_open_place/action_bank.py
@@ -281,7 +281,10 @@ class DrawerOpenPlaceActionBank(ActionBank):
             return DrawerOpenPlaceActionBank.stand_still(
                 env, agent_uid, keypose_names, duration
             )
-        positions = ret.positions
+        # MotionGenerator returns trajectories batched by environment. The action
+        # graph expects joint-major 2-D data, so remove the single-environment
+        # batch dimension before transposing.
+        positions = ret.positions[0]
         if isinstance(positions, torch.Tensor):
             positions = positions.detach().cpu().numpy()
         return positions.T.astype(np.float32)


### PR DESCRIPTION
## Description

Fixes Drawer Open & Place configuration and trajectory-shape handling:

- use lowercase joint-property selector names in all Drawer Open & Place configs
- explicitly set the relevant drawer drives to `none`
- remove the single-environment batch dimension from motion-generator positions before transposing for the action graph

No additional dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [ ] I have run the `black .` command to format the code base.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Dependencies have been updated, if applicable.

Validation performed:

- `python -m json.tool` for each edited configuration
- `python -m py_compile robosynchallenge/tasks/drawer_open_place/action_bank.py`