### PR TITLE
Standardize lighting across environment configs

### DIFF
--- a/configs/click_bell/clear/gym_config.json
+++ b/configs/click_bell/clear/gym_config.json
@@ -196,18 +196,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/click_bell/gym_config_align_real.json
+++ b/configs/click_bell/gym_config_align_real.json
@@ -188,20 +188,12 @@
         }
     ],
     "light": {
-        "indirect": [
-            {
-                "emission_light":{
-                    "color": [1.0, 1.0, 1.0],
-                    "intensity": 1000
-                }
-            }
-        ],
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 10.0,
+                "intensity": 5.0,
                 "init_pos": [0.3, -0.8, 1.5],
                 "radius": 3.0
             },
@@ -209,7 +201,7 @@
                 "uid": "light_1",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 10.0,
+                "intensity": 5.0,
                 "init_pos": [0.3, 0.8, 1.5],
                 "radius": 3.0
             }

--- a/configs/click_bell/gym_config_random_test.json
+++ b/configs/click_bell/gym_config_random_test.json
@@ -342,18 +342,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/click_bell/gym_config_table_height.json
+++ b/configs/click_bell/gym_config_table_height.json
@@ -205,20 +205,12 @@
         }
     ],
     "light": {
-        "indirect": [
-            {
-                "emission_light":{
-                    "color": [1.0, 1.0, 1.0],
-                    "intensity": 1000
-                }
-            }
-        ],
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 10.0,
+                "intensity": 5.0,
                 "init_pos": [0.3, -0.8, 1.5],
                 "radius": 3.0
             },
@@ -226,7 +218,7 @@
                 "uid": "light_1",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 10.0,
+                "intensity": 5.0,
                 "init_pos": [0.3, 0.8, 1.5],
                 "radius": 3.0
             }

--- a/configs/click_bell/random/gym_config.json
+++ b/configs/click_bell/random/gym_config.json
@@ -316,18 +316,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/click_bell/random_eval_once/gym_config.json
+++ b/configs/click_bell/random_eval_once/gym_config.json
@@ -311,18 +311,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/drawer_open_place/clear/gym_config.json
+++ b/configs/drawer_open_place/clear/gym_config.json
@@ -453,18 +453,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/drawer_open_place/gym_config_random_test.json
+++ b/configs/drawer_open_place/gym_config_random_test.json
@@ -609,18 +609,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/drawer_open_place/random/gym_config.json
+++ b/configs/drawer_open_place/random/gym_config.json
@@ -583,18 +583,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/drawer_open_place/random_eval_once/gym_config.json
+++ b/configs/drawer_open_place/random_eval_once/gym_config.json
@@ -576,18 +576,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/handle_basket/clear/gym_config.json
+++ b/configs/handle_basket/clear/gym_config.json
@@ -384,16 +384,6 @@
     }
   ],
   "light": {
-    "indirect": {
-      "emission_light": {
-        "color": [
-          1.0,
-          1.0,
-          1.0
-        ],
-        "intensity": 180
-      }
-    },
     "direct": [
       {
         "uid": "light_0",
@@ -403,7 +393,7 @@
           1.0,
           1.0
         ],
-        "intensity": 15.0,
+        "intensity": 5.0,
         "init_pos": [
           0.8,
           0.0,

--- a/configs/handle_basket/gym_config_random_test.json
+++ b/configs/handle_basket/gym_config_random_test.json
@@ -778,16 +778,6 @@
     }
   ],
   "light": {
-    "indirect": {
-      "emission_light": {
-        "color": [
-          1.0,
-          1.0,
-          1.0
-        ],
-        "intensity": 180
-      }
-    },
     "direct": [
       {
         "uid": "light_0",
@@ -797,7 +787,7 @@
           1.0,
           1.0
         ],
-        "intensity": 15.0,
+        "intensity": 5.0,
         "init_pos": [
           0.8,
           0.0,

--- a/configs/handle_basket/random/gym_config.json
+++ b/configs/handle_basket/random/gym_config.json
@@ -752,16 +752,6 @@
     }
   ],
   "light": {
-    "indirect": {
-      "emission_light": {
-        "color": [
-          1.0,
-          1.0,
-          1.0
-        ],
-        "intensity": 180
-      }
-    },
     "direct": [
       {
         "uid": "light_0",
@@ -771,7 +761,7 @@
           1.0,
           1.0
         ],
-        "intensity": 15.0,
+        "intensity": 5.0,
         "init_pos": [
           0.8,
           0.0,

--- a/configs/handle_basket/random_eval_once/gym_config.json
+++ b/configs/handle_basket/random_eval_once/gym_config.json
@@ -746,16 +746,6 @@
     }
   ],
   "light": {
-    "indirect": {
-      "emission_light": {
-        "color": [
-          1.0,
-          1.0,
-          1.0
-        ],
-        "intensity": 180
-      }
-    },
     "direct": [
       {
         "uid": "light_0",
@@ -765,7 +755,7 @@
           1.0,
           1.0
         ],
-        "intensity": 15.0,
+        "intensity": 5.0,
         "init_pos": [
           0.8,
           0.0,

--- a/configs/item_assembly/clear/gym_config.json
+++ b/configs/item_assembly/clear/gym_config.json
@@ -266,18 +266,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/item_assembly/random/gym_config.json
+++ b/configs/item_assembly/random/gym_config.json
@@ -430,18 +430,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/item_assembly/random_eval_once/gym_config.json
+++ b/configs/item_assembly/random_eval_once/gym_config.json
@@ -400,18 +400,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/items_handover/clear/gym_config.json
+++ b/configs/items_handover/clear/gym_config.json
@@ -258,18 +258,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/items_handover/gym_config_random_test.json
+++ b/configs/items_handover/gym_config_random_test.json
@@ -431,18 +431,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/items_handover/random/gym_config.json
+++ b/configs/items_handover/random/gym_config.json
@@ -405,18 +405,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/items_handover/random_eval_once/gym_config.json
+++ b/configs/items_handover/random_eval_once/gym_config.json
@@ -399,18 +399,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/manipulate_pipette/clear/gym_config.json
+++ b/configs/manipulate_pipette/clear/gym_config.json
@@ -301,18 +301,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/manipulate_pipette/gym_config_random_test.json
+++ b/configs/manipulate_pipette/gym_config_random_test.json
@@ -447,18 +447,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/manipulate_pipette/random/gym_config.json
+++ b/configs/manipulate_pipette/random/gym_config.json
@@ -421,18 +421,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/manipulate_pipette/random_eval_once/gym_config.json
+++ b/configs/manipulate_pipette/random_eval_once/gym_config.json
@@ -416,18 +416,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/mixer_operating/clear/gym_config.json
+++ b/configs/mixer_operating/clear/gym_config.json
@@ -301,18 +301,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/mixer_operating/gym_config_before.json
+++ b/configs/mixer_operating/gym_config_before.json
@@ -452,7 +452,7 @@
                 "uid": "light_1",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 50.0,
+                "intensity": 5.0,
                 "init_pos": [2.0, 0.0, 2.0],
                 "radius": 10.0
             }

--- a/configs/mixer_operating/gym_config_dual_random_test.json
+++ b/configs/mixer_operating/gym_config_dual_random_test.json
@@ -463,18 +463,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/mixer_operating/random/gym_config.json
+++ b/configs/mixer_operating/random/gym_config.json
@@ -437,18 +437,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/mixer_operating/random_eval_once/gym_config.json
+++ b/configs/mixer_operating/random_eval_once/gym_config.json
@@ -432,18 +432,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/manipulate_pipette_two_beaker/clear/gym_config.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/clear/gym_config.json
@@ -345,18 +345,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/manipulate_pipette_two_beaker/gym_config_two_beaker_random_test.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/gym_config_two_beaker_random_test.json
@@ -465,18 +465,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/manipulate_pipette_two_beaker/random/gym_config.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/random/gym_config.json
@@ -465,18 +465,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/manipulate_pipette_two_beaker/random_eval_once/gym_config.json
+++ b/configs/other_tasks/manipulate_pipette_two_beaker/random_eval_once/gym_config.json
@@ -460,18 +460,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/open_pan/clear/gym_config.json
+++ b/configs/other_tasks/open_pan/clear/gym_config.json
@@ -296,18 +296,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/open_pan/gym_config.json
+++ b/configs/other_tasks/open_pan/gym_config.json
@@ -366,7 +366,7 @@
                 "uid": "light_1",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 50.0,
+                "intensity": 5.0,
                 "init_pos": [2.0, 0.0, 2.0],
                 "radius": 10.0
             }

--- a/configs/other_tasks/open_pan/gym_config_random_test.json
+++ b/configs/other_tasks/open_pan/gym_config_random_test.json
@@ -464,18 +464,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/open_pan/random/gym_config.json
+++ b/configs/other_tasks/open_pan/random/gym_config.json
@@ -438,18 +438,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/open_pan/random_eval_once/gym_config.json
+++ b/configs/other_tasks/open_pan/random_eval_once/gym_config.json
@@ -431,18 +431,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/other_tasks/pour_water/gym_config.json
+++ b/configs/other_tasks/pour_water/gym_config.json
@@ -499,7 +499,7 @@
                 "uid": "light_1",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 50.0,
+                "intensity": 5.0,
                 "init_pos": [2, 0, 2],
                 "radius": 10.0
             }

--- a/configs/other_tasks/pour_water/gym_config_dual.json
+++ b/configs/other_tasks/pour_water/gym_config_dual.json
@@ -578,7 +578,7 @@
                 "uid": "light_1",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 50.0,
+                "intensity": 5.0,
                 "init_pos": [2, 0, 2],
                 "radius": 10.0
             }

--- a/configs/other_tasks/sample_loading/gym_config.json
+++ b/configs/other_tasks/sample_loading/gym_config.json
@@ -352,7 +352,7 @@
                 "uid": "light_1",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 50.0,
+                "intensity": 5.0,
                 "init_pos": [2, 0, 2],
                 "radius": 10.0
             }

--- a/configs/sample_loading/clear/gym_config.json
+++ b/configs/sample_loading/clear/gym_config.json
@@ -249,18 +249,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/sample_loading/gym_config_random_test.json
+++ b/configs/sample_loading/gym_config_random_test.json
@@ -411,18 +411,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/sample_loading/random/gym_config.json
+++ b/configs/sample_loading/random/gym_config.json
@@ -385,18 +385,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/sample_loading/random_eval_once/gym_config.json
+++ b/configs/sample_loading/random_eval_once/gym_config.json
@@ -380,18 +380,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/table_rearrangement/clear/gym_config.json
+++ b/configs/table_rearrangement/clear/gym_config.json
@@ -218,18 +218,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/table_rearrangement/gym_config_random_test.json
+++ b/configs/table_rearrangement/gym_config_random_test.json
@@ -386,18 +386,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/table_rearrangement/random/gym_config.json
+++ b/configs/table_rearrangement/random/gym_config.json
@@ -360,18 +360,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/table_rearrangement/random_eval_once/gym_config.json
+++ b/configs/table_rearrangement/random_eval_once/gym_config.json
@@ -353,18 +353,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/water_pouring/clear/gym_config.json
+++ b/configs/water_pouring/clear/gym_config.json
@@ -247,18 +247,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/water_pouring/gym_config_dual_green_clear.json
+++ b/configs/water_pouring/gym_config_dual_green_clear.json
@@ -247,18 +247,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/water_pouring/gym_config_dual_random_test.json
+++ b/configs/water_pouring/gym_config_dual_random_test.json
@@ -420,18 +420,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/water_pouring/random/gym_config.json
+++ b/configs/water_pouring/random/gym_config.json
@@ -394,18 +394,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }

--- a/configs/water_pouring/random_eval_once/gym_config.json
+++ b/configs/water_pouring/random_eval_once/gym_config.json
@@ -388,18 +388,12 @@
         }
     ],
     "light": {
-        "indirect": {
-            "emission_light":{
-                "color": [1.0, 1.0, 1.0],
-                "intensity": 180
-            }
-        },
         "direct": [
             {
                 "uid": "light_0",
                 "light_type": "point",
                 "color": [1.0, 1.0, 1.0],
-                "intensity": 15.0,
+                "intensity": 5.0,
                 "init_pos": [0.8, 0.0, 2.0],
                 "radius": 20.0
             }


### PR DESCRIPTION
## Summary

- remove indirect emission lighting from environment configurations
- set all direct point-light intensities to 5.0

## Validation

- parsed all 72 JSON config files successfully