### PR TITLE
Add dynamic replay and tune CobotMagic contact physics

### DIFF
--- a/configs/drawer_open_place/clear/gym_config.json
+++ b/configs/drawer_open_place/clear/gym_config.json
@@ -2,6 +2,9 @@
     "id": "DrawerOpenPlace",
     "max_episodes": 100,
     "max_episode_steps": 900,
+    "physics": {
+        "enable_ccd": true
+    },
     "env": {
         "events": {
             "set_drawer_material": {
@@ -380,22 +383,37 @@
         "robot_type": "CobotMagic",
         "init_pos": [0.0, 0.0, 0.835],
         "init_qpos": [-0.05918411, 0.08932595, 0.00076794, 0.00970403, -0.12870058, -0.21027726, -0.13548991, -0.08838347, 0.29586821,0.39285615,0.13372713,0.08686504,0.0,0.0,0.0,0.0],
+        "min_position_iters": 32,
+        "min_velocity_iters": 8,
         "attrs": {
-            "contact_offset": 0.0002,
-            "rest_offset": 0.00005
+            "enable_ccd": true
         },
         "drive_pros": {
             "stiffness": {
-                "left_joint[7-8]": 600.0,
-                "right_joint[7-8]": 600.0
+                "left_joint[1-6]": 5000.0,
+                "right_joint[1-6]": 5000.0,
+                "left_joint[7-8]": 150.0,
+                "right_joint[7-8]": 150.0
             },
             "damping": {
-                "left_joint[7-8]": 60.0,
-                "right_joint[7-8]": 60.0
+                "left_joint[1-6]": 800.0,
+                "right_joint[1-6]": 800.0,
+                "left_joint[7-8]": 20.0,
+                "right_joint[7-8]": 20.0
             },
             "max_effort": {
-                "left_joint[7-8]": 6000.0,
-                "right_joint[7-8]": 6000.0
+                "left_joint[1-6]": 150.0,
+                "right_joint[1-6]": 150.0,
+                "left_joint[7-8]": 15.0,
+                "right_joint[7-8]": 15.0
+            },
+            "max_velocity": {
+                "left_joint[1-5]": 2.0,
+                "right_joint[1-5]": 2.0,
+                "left_joint6": 1.5,
+                "right_joint6": 1.5,
+                "left_joint[7-8]": 0.5,
+                "right_joint[7-8]": 0.5
             }
         }
     },
@@ -614,9 +632,12 @@
                 0,
                 180
             ],
+            "min_position_iters": 32,
+            "min_velocity_iters": 8,
             "attrs": {
                 "static_friction": 5.0,
-                "dynamic_friction": 4.8
+                "dynamic_friction": 4.8,
+                "enable_ccd": true
             },
             "drive_pros": {
                 "drive_type": "none",
@@ -634,8 +655,7 @@
             "attrs": {
                 "static_friction": 5.0,
                 "dynamic_friction": 4.8,
-                "contact_offset": 0.0002,
-                "rest_offset": 0.00005
+                "enable_ccd": true
             },
             "drive_pros": {
                 "drive_type": "none",

--- a/configs/drawer_open_place/random/gym_config.json
+++ b/configs/drawer_open_place/random/gym_config.json
@@ -2,6 +2,9 @@
     "id": "DrawerOpenPlace",
     "max_episodes": 100,
     "max_episode_steps": 900,
+    "physics": {
+        "enable_ccd": true
+    },
     "env": {
         "events": {
             "random_light": {
@@ -510,22 +513,40 @@
         "robot_type": "CobotMagic",
         "init_pos": [0.0, 0.0, 0.835],
         "init_qpos": [-0.05918411, 0.08932595, 0.00076794, 0.00970403, -0.12870058, -0.21027726, -0.13548991, -0.08838347, 0.29586821,0.39285615,0.13372713,0.08686504,0.0,0.0,0.0,0.0],
+        "min_position_iters": 32,
+        "min_velocity_iters": 8,
         "attrs": {
-            "contact_offset": 0.0002,
-            "rest_offset": 0.00005
+            "contact_offset": 0.003,
+            "rest_offset": 0.001,
+            "max_depenetration_velocity": 1.0,
+            "enable_ccd": true
         },
         "drive_pros": {
             "stiffness": {
-                "left_joint[7-8]": 600.0,
-                "right_joint[7-8]": 600.0
+                "left_joint[1-6]": 5000.0,
+                "right_joint[1-6]": 5000.0,
+                "left_joint[7-8]": 150.0,
+                "right_joint[7-8]": 150.0
             },
             "damping": {
-                "left_joint[7-8]": 60.0,
-                "right_joint[7-8]": 60.0
+                "left_joint[1-6]": 800.0,
+                "right_joint[1-6]": 800.0,
+                "left_joint[7-8]": 20.0,
+                "right_joint[7-8]": 20.0
             },
             "max_effort": {
-                "left_joint[7-8]": 6000.0,
-                "right_joint[7-8]": 6000.0
+                "left_joint[1-6]": 150.0,
+                "right_joint[1-6]": 150.0,
+                "left_joint[7-8]": 15.0,
+                "right_joint[7-8]": 15.0
+            },
+            "max_velocity": {
+                "left_joint[1-5]": 2.0,
+                "right_joint[1-5]": 2.0,
+                "left_joint6": 1.5,
+                "right_joint6": 1.5,
+                "left_joint[7-8]": 0.5,
+                "right_joint[7-8]": 0.5
             }
         }
     },
@@ -758,9 +779,15 @@
                 0,
                 180
             ],
+            "min_position_iters": 32,
+            "min_velocity_iters": 8,
             "attrs": {
                 "static_friction": 5.0,
-                "dynamic_friction": 4.8
+                "dynamic_friction": 4.8,
+                "contact_offset": 0.003,
+                "rest_offset": 0.001,
+                "max_depenetration_velocity": 1.0,
+                "enable_ccd": true
             },
             "drive_pros": {
                 "drive_type": "none",
@@ -778,8 +805,10 @@
             "attrs": {
                 "static_friction": 5.0,
                 "dynamic_friction": 4.8,
-                "contact_offset": 0.0002,
-                "rest_offset": 0.00005
+                "contact_offset": 0.003,
+                "rest_offset": 0.001,
+                "max_depenetration_velocity": 1.0,
+                "enable_ccd": true
             },
             "drive_pros": {
                 "stiffness": 10.0,

--- a/launch/README.md
+++ b/launch/README.md
@@ -8,6 +8,7 @@
 |---|---|
 | `check_all_envs.sh` | 依次运行全部任务环境，检测是否有 bug |
 | `run_task.sh` | 运行单个任务环境，收集专家演示数据 |
+| `replay_task.sh` | 以 kinematic、dynamic 或 control 模式回放轨迹 |
 | `collect_combined_dataset.sh` | 收集 clear + random 数据集并自动合并 |
 | `run_visualize.sh` | 可视化单个任务的域随机化效果 |
 | `batch_run_visualize.sh` | 批量可视化所有任务的域随机化效果 |
@@ -50,6 +51,29 @@
 ```
 
 数据保存路径为 `lerobot_dataset/<task_name>/`。
+
+---
+
+## replay_task.sh
+
+回放 EmbodiChain 原生轨迹，或旧版 `state/action/reward` 格式的单环境轨迹。
+
+```
+用法:
+  ./launch/replay_task.sh <task_name> <setting> <trajectory.pt> [extra_args...]
+```
+
+**示例：**
+
+```bash
+# 通过物理仿真回放 drawer_open_place 动作
+./launch/replay_task.sh drawer_open_place random /path/to/state_action.pt --replay_mode dynamic
+
+# 仅恢复机器人运动学状态
+./launch/replay_task.sh drawer_open_place clear /path/to/state_action.pt --replay_mode kinematic
+```
+
+`dynamic` 模式会将记录的 action 重新送入环境，由物理引擎重新计算机器人和场景物体的交互。旧版轨迹不包含抽屉等场景物体的状态，因此要复现物体交互时应使用该模式。
 
 ---
 

--- a/launch/replay_task.sh
+++ b/launch/replay_task.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./replay_task.sh <task_name> <setting(random|clear)> <trajectory.pt> [extra_args...]
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
+if [[ "$#" -eq 1 && ("$1" == "-h" || "$1" == "--help") ]]; then
+    echo "Usage:"
+    echo "  $0 <task_name> <setting(random|clear)> <trajectory.pt> [extra_args...]"
+    echo
+    echo "Examples:"
+    echo "  $0 drawer_open_place random /path/to/state_action.pt --replay_mode dynamic"
+    echo "  $0 drawer_open_place clear /path/to/trajectory.pt --replay_mode kinematic"
+    exit 0
+fi
+
+if [ "$#" -lt 3 ]; then
+    echo "Error: task name, setting, and trajectory path are required." >&2
+    echo "Run $0 --help for usage." >&2
+    exit 1
+fi
+
+TASK_NAME=$1
+SETTING=$2
+TRAJECTORY=$3
+shift 3
+
+GYM_CONFIG="configs/${TASK_NAME}/${SETTING}/gym_config.json"
+if [ -f "configs/${TASK_NAME}/action_config.json" ]; then
+    ACTION_CONFIG="configs/${TASK_NAME}/action_config.json"
+else
+    ACTION_CONFIG="configs/${TASK_NAME}/${SETTING}/action_config.json"
+fi
+
+if [ ! -f "$GYM_CONFIG" ]; then
+    echo "Error: Cannot find gym config: $GYM_CONFIG" >&2
+    exit 1
+fi
+if [ ! -f "$ACTION_CONFIG" ]; then
+    echo "Error: Cannot find action config: $ACTION_CONFIG" >&2
+    exit 1
+fi
+if [ ! -f "$TRAJECTORY" ]; then
+    echo "Error: Cannot find trajectory: $TRAJECTORY" >&2
+    exit 1
+fi
+
+RUN_CMD=(
+    python -m scripts.run_env
+    --gym_config "$GYM_CONFIG"
+    --action_config "$ACTION_CONFIG"
+    --num_envs 1
+    --filter_dataset_saving
+    --replay
+    --replay_trajectory "$TRAJECTORY"
+)
+RUN_CMD+=("$@")
+
+echo "Replaying task: $TASK_NAME ($SETTING)"
+echo "Trajectory: $TRAJECTORY"
+echo "Running command:"
+echo "${RUN_CMD[@]}"
+"${RUN_CMD[@]}"

--- a/robosynchallenge/replay.py
+++ b/robosynchallenge/replay.py
@@ -1,0 +1,269 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-2026 DexForce Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+"""Trajectory replay compatibility helpers for RoboSynChallenge."""
+
+from __future__ import annotations
+
+from os import PathLike
+from typing import Any, Literal
+
+import torch
+from tensordict import TensorDict
+
+from embodichain.lab.gym.envs.wrapper import ReplayWrapper
+from embodichain.lab.scripts.run_env import replay as replay_native_trajectory
+from embodichain.lab.scripts.run_env import replay_auto, replay_control
+from embodichain.utils.logger import log_info, log_warning
+
+__all__ = ["convert_state_action_trajectory", "replay_trajectory"]
+
+ReplayMode = Literal["kinematic", "dynamic", "control"]
+
+
+def _as_batched_trajectory(value: Any, key: str) -> torch.Tensor:
+    """Return a legacy trajectory tensor in ``(num_envs, steps, dim)`` form."""
+    tensor = torch.as_tensor(value, dtype=torch.float32, device="cpu")
+    if tensor.ndim == 2:
+        tensor = tensor.unsqueeze(0)
+    if tensor.ndim != 3:
+        raise ValueError(
+            f"Legacy trajectory {key!r} must have shape (steps, dim) or "
+            f"(num_envs, steps, dim), got {tuple(tensor.shape)}."
+        )
+    if tensor.shape[0] != 1:
+        raise ValueError(
+            "Legacy state/action replay currently expects one recorded environment, "
+            f"got {tensor.shape[0]}."
+        )
+    return tensor
+
+
+def _valid_state_prefix(states: torch.Tensor) -> int:
+    """Return the number of consecutive finite state frames."""
+    finite_steps = torch.isfinite(states).all(dim=-1).all(dim=0)
+    invalid = (~finite_steps).nonzero(as_tuple=False)
+    if len(invalid) == 0:
+        return int(states.shape[1])
+    return int(invalid[0].item())
+
+
+def _denormalize_eef_states(states: torch.Tensor, env: Any) -> torch.Tensor:
+    """Convert normalized CobotMagic gripper observations back to joint qpos."""
+    result = states.clone()
+    active_joint_ids = list(env.active_joint_ids)
+    global_to_active = {
+        joint_id: active_idx for active_idx, joint_id in enumerate(active_joint_ids)
+    }
+
+    eef_active_indices: list[int] = []
+    for control_part in ("left_eef", "right_eef"):
+        for joint_id in env.robot.get_joint_ids(name=control_part, remove_mimic=True):
+            if joint_id in global_to_active:
+                eef_active_indices.append(global_to_active[joint_id])
+
+    if not eef_active_indices:
+        return result
+
+    active_indices = torch.as_tensor(eef_active_indices, dtype=torch.long)
+    robot_joint_ids = torch.as_tensor(
+        [active_joint_ids[idx] for idx in eef_active_indices],
+        device=env.device,
+        dtype=torch.long,
+    )
+    limits = (
+        env.robot.body_data.qpos_limits[0, robot_joint_ids]
+        .detach()
+        .to(device="cpu", dtype=result.dtype)
+    )
+    low = limits[:, 0]
+    high = limits[:, 1]
+    result[..., active_indices] = low + result[..., active_indices] * (high - low)
+    return result
+
+
+def _expand_active_qpos(states: torch.Tensor, env: Any) -> torch.Tensor:
+    """Expand active-joint qpos into the robot's complete qpos representation."""
+    num_envs, num_steps, action_dim = states.shape
+    active_joint_ids = list(env.active_joint_ids)
+    if action_dim != len(active_joint_ids):
+        raise ValueError(
+            f"Legacy trajectory has {action_dim} joints, but the replay environment "
+            f"has {len(active_joint_ids)} active joints ({active_joint_ids})."
+        )
+
+    active_ids_tensor = torch.as_tensor(
+        active_joint_ids, device=env.device, dtype=torch.long
+    )
+    active_limits = (
+        env.robot.body_data.qpos_limits[0, active_ids_tensor]
+        .detach()
+        .to(device="cpu", dtype=states.dtype)
+    )
+    low = active_limits[:, 0]
+    high = active_limits[:, 1]
+    out_of_range = (states < low) | (states > high)
+    if bool(out_of_range.any()):
+        value_count = int(out_of_range.sum().item())
+        step_count = int(out_of_range.any(dim=-1).sum().item())
+        log_warning(
+            f"Clamping {value_count} out-of-range legacy state values across "
+            f"{step_count} frames to the robot joint limits."
+        )
+        states = states.clamp(low, high)
+
+    initial_qpos = (
+        env.robot.get_qpos()
+        .detach()
+        .to(device="cpu", dtype=states.dtype)
+        .expand(num_envs, -1)
+    )
+    qpos = initial_qpos[:, None, :].expand(num_envs, num_steps, -1).clone()
+    qpos[..., active_joint_ids] = states
+
+    mimic_ids = list(env.robot.mimic_ids)
+    mimic_parents = list(env.robot.mimic_parents)
+    mimic_multipliers = list(env.robot.mimic_multipliers)
+    mimic_offsets = list(env.robot.mimic_offsets)
+    for mimic_id, parent_id, multiplier, offset in zip(
+        mimic_ids, mimic_parents, mimic_multipliers, mimic_offsets
+    ):
+        if mimic_id is None or parent_id is None:
+            continue
+        qpos[..., mimic_id] = qpos[..., parent_id] * multiplier + offset
+
+    return qpos
+
+
+def convert_state_action_trajectory(
+    data: dict[str, Any],
+    env: Any,
+    mode: ReplayMode = "kinematic",
+) -> dict[str, Any]:
+    """Convert a legacy ``state/action/reward`` file for ``ReplayWrapper``.
+
+    The legacy format stores only the robot's 14 active CobotMagic joints. It
+    does not contain drawer or rigid-object poses, so kinematic/control replay
+    reproduces robot motion only. Dynamic replay feeds the recorded actions
+    through physics and can therefore move scene objects.
+    """
+    if "state" not in data or "action" not in data:
+        raise ValueError(
+            "Unsupported trajectory format. Expected EmbodiChain "
+            "states/actions/meta or legacy state/action/reward keys."
+        )
+
+    states = _as_batched_trajectory(data["state"], "state")
+    actions = _as_batched_trajectory(data["action"], "action")
+    if states.shape[:2] != actions.shape[:2]:
+        raise ValueError(
+            "Legacy state/action lengths do not match: "
+            f"state={tuple(states.shape)}, action={tuple(actions.shape)}."
+        )
+    if not bool(torch.isfinite(actions).all()):
+        raise ValueError("Legacy trajectory contains non-finite actions.")
+
+    finite_prefix = _valid_state_prefix(states)
+    if finite_prefix == 0:
+        raise ValueError("Legacy trajectory has no finite state frames.")
+
+    if mode in ("kinematic", "control"):
+        num_steps = finite_prefix
+        if num_steps < states.shape[1]:
+            log_warning(
+                f"Legacy state trajectory becomes non-finite at step {num_steps}; "
+                f"replaying its {num_steps} valid frames."
+            )
+        states = states[:, :num_steps]
+        actions = actions[:, :num_steps]
+    else:
+        num_steps = int(actions.shape[1])
+        if finite_prefix < num_steps:
+            log_warning(
+                f"Legacy state trajectory becomes non-finite at step {finite_prefix}; "
+                "dynamic replay will continue with the finite action trajectory."
+            )
+            states = states.clone()
+            states[:, finite_prefix:] = states[:, finite_prefix - 1 : finite_prefix]
+
+    physical_states = _denormalize_eef_states(states, env)
+    robot_qpos = _expand_active_qpos(physical_states, env)
+    root_pose = (
+        env.robot.get_local_pose()
+        .detach()
+        .to(device="cpu", dtype=torch.float32)
+        .unsqueeze(1)
+        .expand(-1, num_steps, -1)
+        .clone()
+    )
+    robot_states = TensorDict(
+        {"root_pose": root_pose, "qpos": robot_qpos},
+        batch_size=[states.shape[0], num_steps],
+        device="cpu",
+    )
+    replay_states = TensorDict(
+        {"robot": robot_states},
+        batch_size=[states.shape[0], num_steps],
+        device="cpu",
+    )
+    meta = {
+        "lengths": [num_steps],
+        "num_steps": num_steps,
+        "num_envs": int(states.shape[0]),
+        "active_joint_ids": list(env.active_joint_ids),
+        "robot_uid": env.robot.uid,
+        "robot_dof": int(env.robot.dof),
+        "source_format": "state_action",
+    }
+    return {"states": replay_states, "actions": actions, "meta": meta}
+
+
+def replay_trajectory(
+    env: Any,
+    trajectory_path: str | PathLike[str],
+    mode: ReplayMode = "kinematic",
+) -> None:
+    """Replay a native EmbodiChain or legacy RoboSynChallenge trajectory."""
+    data = torch.load(trajectory_path, map_location="cpu", weights_only=False)
+    if not isinstance(data, dict):
+        raise ValueError(f"Trajectory root must be a dict, got {type(data).__name__}.")
+
+    if {"states", "actions", "meta"}.issubset(data):
+        replay_native_trajectory(env, str(trajectory_path), mode=mode)
+        return
+
+    converted = convert_state_action_trajectory(data, env.unwrapped, mode=mode)
+    meta = converted["meta"]
+    log_info(
+        f"Replaying legacy state/action trajectory: num_envs={meta['num_envs']}, "
+        f"num_steps={meta['num_steps']}, mode={mode}",
+        color="green",
+    )
+    if mode in ("kinematic", "control"):
+        log_warning(
+            "This legacy file has no drawer or rigid-object states; kinematic replay "
+            "reproduces robot motion only. Use --replay_mode dynamic to re-simulate "
+            "object interaction from the recorded actions."
+        )
+
+    replay_env = ReplayWrapper(env.unwrapped, converted, mode=mode)
+    try:
+        if mode == "control":
+            replay_control(replay_env)
+        else:
+            replay_auto(replay_env, mode)
+    finally:
+        replay_env.close()

--- a/robosynchallenge/tasks/_other_tasks/manipulate_pipette_two_beaker/manipulate_pipette_two_beaker.py
+++ b/robosynchallenge/tasks/_other_tasks/manipulate_pipette_two_beaker/manipulate_pipette_two_beaker.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     ManipulatePipetteTwoBeakerActionBank,
 )

--- a/robosynchallenge/tasks/_other_tasks/open_pan/open_pan.py
+++ b/robosynchallenge/tasks/_other_tasks/open_pan/open_pan.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 from robosynchallenge.managers.events import visualize_rigid_body_pose
 from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 

--- a/robosynchallenge/tasks/_other_tasks/pour_water/pour_water.py
+++ b/robosynchallenge/tasks/_other_tasks/pour_water/pour_water.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from embodichain.lab.gym.envs.tasks.tableware.pour_water.action_bank import (
     PourWaterActionBank,
 )

--- a/robosynchallenge/tasks/_other_tasks/sample_loading/sample_loading.py
+++ b/robosynchallenge/tasks/_other_tasks/sample_loading/sample_loading.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     SampleLoadingActionBank,
 )

--- a/robosynchallenge/tasks/click_bell/click_bell.py
+++ b/robosynchallenge/tasks/click_bell/click_bell.py
@@ -22,7 +22,7 @@ from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 from embodichain.lab.sim.cfg import MarkerCfg
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     ClickBellActionBank,
 )

--- a/robosynchallenge/tasks/drawer_open_place/drawer_open_place.py
+++ b/robosynchallenge/tasks/drawer_open_place/drawer_open_place.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Tuple
 from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from embodichain.utils import logger
 
 from .action_bank import DrawerOpenPlaceActionBank

--- a/robosynchallenge/tasks/handle_basket/handle_basket.py
+++ b/robosynchallenge/tasks/handle_basket/handle_basket.py
@@ -25,7 +25,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 from robosynchallenge.managers.events import visualize_rigid_body_pose
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import HandleBasketActionBank
 
 __all__ = ["HandleBasketEnv", "HandleBasketTestEnv", "HandleBasketAgentEnv"]

--- a/robosynchallenge/tasks/item_assembly/item_assembly.py
+++ b/robosynchallenge/tasks/item_assembly/item_assembly.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 from robosynchallenge.managers.events import visualize_rigid_body_pose
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     ItemAssemblyActionBank,
 )

--- a/robosynchallenge/tasks/items_handover/items_handover.py
+++ b/robosynchallenge/tasks/items_handover/items_handover.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     ItemsHandoverActionBank,
 )

--- a/robosynchallenge/tasks/manipulate_pipette/manipulate_pipette.py
+++ b/robosynchallenge/tasks/manipulate_pipette/manipulate_pipette.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     ManipulatePipetteActionBank,
 )

--- a/robosynchallenge/tasks/mixer_operating/mixer_operating.py
+++ b/robosynchallenge/tasks/mixer_operating/mixer_operating.py
@@ -22,7 +22,7 @@ from embodichain.lab.gym.utils.registration import register_env
 from robosynchallenge.managers.events import visualize_affordance_pose
 from embodichain.utils import logger
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import MixerOperatingActionBank
 
 __all__ = ["MixerOperatingEnv", "MixerOperatingTestEnv", "MixerOperatingAgentEnv"]

--- a/robosynchallenge/tasks/sample_loading/sample_loading.py
+++ b/robosynchallenge/tasks/sample_loading/sample_loading.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     SampleLoadingActionBank,
 )

--- a/robosynchallenge/tasks/water_pouring/water_pouring.py
+++ b/robosynchallenge/tasks/water_pouring/water_pouring.py
@@ -21,7 +21,7 @@ from embodichain.lab.gym.envs import EmbodiedEnv, EmbodiedEnvCfg
 from embodichain.lab.gym.utils.registration import register_env
 from embodichain.utils import logger
 from robosynchallenge.managers.events import visualize_rigid_body_pose
-from embodichain.lab.gym.envs.tasks.tableware.base_agent_env import BaseAgentEnv
+from embodichain_tasks.tableware.base_agent_env import BaseAgentEnv
 from .action_bank import (
     WaterPouringActionBank,
 )

--- a/scripts/run_env.py
+++ b/scripts/run_env.py
@@ -23,10 +23,11 @@ import tqdm
 
 import gymnasium as gym
 import robosynchallenge
+from robosynchallenge.replay import replay_trajectory
 
 from embodichain.lab.gym.utils.gym_utils import (
     add_env_launcher_args_to_parser,
-    build_env_cfg_from_args
+    build_env_cfg_from_args,
 )
 import embodichain.lab.gym.utils.gym_utils as gym_utils
 from embodichain.lab.scripts.run_env import generate_and_execute_action_list, preview
@@ -159,6 +160,14 @@ def _generate_until_saved_episode_target(args, env, gym_config, num_traj: int) -
 
 
 def run_env_main(args, env, gym_config):
+    if getattr(args, "replay", False):
+        replay_trajectory(
+            env,
+            args.replay_trajectory,
+            mode=getattr(args, "replay_mode", "kinematic"),
+        )
+        return
+
     if getattr(args, "preview", False):
         log_info(
             "Preview mode enabled. Launching environment preview...", color="green"
@@ -196,9 +205,43 @@ if __name__ == "__main__":
 
     add_env_launcher_args_to_parser(parser)
 
+    parser.add_argument(
+        "--replay",
+        action="store_true",
+        help="Replay a native EmbodiChain or legacy state/action trajectory.",
+    )
+    parser.add_argument(
+        "--replay_trajectory",
+        type=str,
+        default=None,
+        help="Path to the .pt trajectory file to replay.",
+    )
+    parser.add_argument(
+        "--replay_mode",
+        choices=["kinematic", "dynamic", "control"],
+        default="kinematic",
+        help="Replay mode (default: kinematic).",
+    )
+
     args = parser.parse_args()
 
+    if args.replay and not args.replay_trajectory:
+        parser.error("--replay requires --replay_trajectory <path>.")
+    if args.replay and args.preview:
+        parser.error("--replay and --preview are mutually exclusive.")
+    if args.replay:
+        args.filter_dataset_saving = True
+
     env_cfg, gym_config, action_config = build_env_cfg_from_args(args)
+    physics_config = gym_config.get("physics", {})
+    if "enable_ccd" in physics_config:
+        env_cfg.sim_cfg.physics_config.enable_ccd = bool(
+            physics_config["enable_ccd"]
+        )
+        if env_cfg.sim_cfg.physics_config.enable_ccd:
+            log_info(
+                "Scene-level continuous collision detection enabled.", color="green"
+            )
     if args.max_episodes is not None:
         gym_config["max_episodes"] = args.max_episodes
 


### PR DESCRIPTION
## Summary

- add native and legacy state/action trajectory replay support with kinematic, dynamic, and control modes
- add a reusable replay_task.sh launcher and usage documentation
- update task imports for the EmbodiChain main package layout
- tune drawer_open_place and items_handover CobotMagic drives for softer contact and higher solver accuracy
- enable scene-level and body-level CCD for the tuned tasks
- enable CCD and lower depenetration velocity for the items_handover holder and pen

## Validation

- parsed all modified drawer_open_place and items_handover JSON configurations
- verified the final CobotMagic configuration merge for stiffness, damping, effort, velocity, contact offsets, solver iterations, and CCD
- compiled the modified Python entry points and validated replay_task.sh
- completed all 427 frames of the supplied drawer trajectory in random dynamic headless mode with CCD enabled
- completed the items_handover clear expert action sequence through 327/327 steps with CCD enabled
- git diff --check passed

## Notes

The supplied legacy drawer trajectory has non-finite state values starting at frame 422 and out-of-range recorded states. Dynamic replay continues using the finite action stream; state values are sanitized for replay metadata and kinematic compatibility.

A repeated items_handover generation attempt can retry when its existing randomized IK validation fails; one validated attempt generated and executed the complete 327-step action sequence.